### PR TITLE
Fix organization setup screen errors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,6 +91,19 @@ const AppRoutes = () => {
         <Route path="/setup" element={<OrganizationSetup />} />
         <Route path="/login" element={<Navigate to="/setup" replace />} />
         <Route path="/register" element={<Navigate to="/setup" replace />} />
+        {/* Allow navigating to /dashboard immediately after org creation to avoid redirect loop */}
+        <Route
+          path="/dashboard"
+          element={
+            <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 flex items-center justify-center">
+              <div className="text-center space-y-4">
+                <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-violet-600 mx-auto"></div>
+                <p className="text-slate-600 font-medium">Finalizing your workspace...</p>
+                <p className="text-sm text-slate-500">If you are not redirected automatically in a moment, reload the page.</p>
+              </div>
+            </div>
+          }
+        />
         <Route path="*" element={<Navigate to="/setup" replace />} />
       </Routes>
     );


### PR DESCRIPTION
Add a temporary loading screen for `/dashboard` to prevent redirect loop after organization creation.

After an organization is created, the application navigates to `/dashboard` before the new organization context is fully loaded. This race condition caused the router to incorrectly redirect back to `/setup`, trapping users on the setup screen.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0802224-89f0-4dfc-b148-406e694f6c7b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a0802224-89f0-4dfc-b148-406e694f6c7b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

