### PR TITLE
Fix service kit foreign key constraint

### DIFF
--- a/supabase/migrations/20250809090000_fix_service_kits_service_fk.sql
+++ b/supabase/migrations/20250809090000_fix_service_kits_service_fk.sql
@@ -1,0 +1,20 @@
+BEGIN;
+
+-- Remove any orphaned service_kits rows that point to non-existent services
+DELETE FROM public.service_kits sk
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.services s WHERE s.id = sk.service_id
+);
+
+-- Drop the existing incorrect foreign key if it exists
+ALTER TABLE public.service_kits
+  DROP CONSTRAINT IF EXISTS service_kits_service_id_fkey;
+
+-- Add the corrected foreign key referencing services(id)
+ALTER TABLE public.service_kits
+  ADD CONSTRAINT service_kits_service_id_fkey
+  FOREIGN KEY (service_id)
+  REFERENCES public.services(id)
+  ON DELETE CASCADE;
+
+COMMIT;


### PR DESCRIPTION
Fix `service_kits.service_id` foreign key to correctly reference `services(id)` to resolve save errors.

The existing `service_kits.service_id` foreign key incorrectly referenced `inventory_items(id)`, while the application logic attempted to link `service_kits` to `services(id)`, leading to foreign key constraint violations during service item creation or update.

---
<a href="https://cursor.com/background-agent?bcId=bc-7cab3f7b-5d00-4966-bdb4-98982370b330">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7cab3f7b-5d00-4966-bdb4-98982370b330">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

