### PR TITLE
Allow multiple services and staff per appointment

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -96,6 +96,67 @@ export type Database = {
           },
         ]
       }
+      appointment_services: {
+        Row: {
+          id: string
+          appointment_id: string
+          service_id: string
+          staff_id: string | null
+          duration_minutes: number | null
+          price: number | null
+          notes: string | null
+          sort_order: number | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          appointment_id: string
+          service_id: string
+          staff_id?: string | null
+          duration_minutes?: number | null
+          price?: number | null
+          notes?: string | null
+          sort_order?: number | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          appointment_id?: string
+          service_id?: string
+          staff_id?: string | null
+          duration_minutes?: number | null
+          price?: number | null
+          notes?: string | null
+          sort_order?: number | null
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "appointment_services_appointment_id_fkey"
+            columns: ["appointment_id"]
+            isOneToOne: false
+            referencedRelation: "appointments"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "appointment_services_service_id_fkey"
+            columns: ["service_id"]
+            isOneToOne: false
+            referencedRelation: "services"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "appointment_services_staff_id_fkey"
+            columns: ["staff_id"]
+            isOneToOne: false
+            referencedRelation: "staff"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       clients: {
         Row: {
           address: string | null


### PR DESCRIPTION
Enable multi-service selection and per-service staff assignment for appointments.

This change introduces a new `appointment_services` table to store individual service details for an appointment, allowing for multiple services to be booked and assigned to different staff members within a single appointment. The appointment creation/edit form and display logic have been updated to reflect this.

---
<a href="https://cursor.com/background-agent?bcId=bc-f7f20829-7f1d-4864-a7e6-61928b7cd2e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f7f20829-7f1d-4864-a7e6-61928b7cd2e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

