### PR TITLE
Fix useOrganizationCurrency hook definition

### DIFF
--- a/src/pages/Invoices.tsx
+++ b/src/pages/Invoices.tsx
@@ -77,6 +77,7 @@ import {
   deleteInvoiceWithFallback,
   getInvoiceItemsWithFallback 
 } from "@/utils/mockDatabase";
+import { useOrganizationCurrency } from "@/lib/saas/hooks";
 
 interface Invoice {
   id: string;

--- a/src/pages/ReceiptView.tsx
+++ b/src/pages/ReceiptView.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
 import { format } from 'date-fns';
+import { useOrganizationCurrency } from '@/lib/saas/hooks';
 
 export default function ReceiptView() {
   const { id } = useParams();

--- a/src/pages/Receipts.tsx
+++ b/src/pages/Receipts.tsx
@@ -11,6 +11,7 @@ import { RefreshCw, DollarSign } from "lucide-react";
 import { format } from "date-fns";
 import { toast } from "sonner";
 import { getReceiptsWithFallback } from "@/utils/mockDatabase";
+import { useOrganizationCurrency } from "@/lib/saas/hooks";
 
 interface Receipt {
   id: string;


### PR DESCRIPTION
Add missing imports for `useOrganizationCurrency` hook to resolve `ReferenceError` in multiple pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-45efdc5d-2a9d-47b1-9736-4f828474169e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-45efdc5d-2a9d-47b1-9736-4f828474169e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

