### PR TITLE
Fix select item value prop

### DIFF
--- a/src/pages/POS.tsx
+++ b/src/pages/POS.tsx
@@ -357,25 +357,29 @@ export default function POS() {
           {/* Customer Selection */}
           <div className="mb-4">
             <Label>Customer (Optional)</Label>
-            <Select 
-              value={selectedCustomer?.id || ""} 
-              onValueChange={(value) => {
-                const customer = customers.find(c => c.id === value);
-                setSelectedCustomer(customer || null);
-              }}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Select customer" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="">Walk-in Customer</SelectItem>
-                {customers.map((customer) => (
-                  <SelectItem key={customer.id} value={customer.id}>
-                    {customer.full_name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+                          <Select 
+               value={selectedCustomer ? selectedCustomer.id : "__walk_in__"} 
+               onValueChange={(value) => {
+                 if (value === "__walk_in__") {
+                   setSelectedCustomer(null);
+                   return;
+                 }
+                 const customer = customers.find(c => c.id === value);
+                 setSelectedCustomer(customer || null);
+               }}
+             >
+               <SelectTrigger>
+                 <SelectValue placeholder="Select customer" />
+               </SelectTrigger>
+               <SelectContent>
+                 <SelectItem value="__walk_in__">Walk-in Customer</SelectItem>
+                 {customers.map((customer) => (
+                   <SelectItem key={customer.id} value={customer.id}>
+                     {customer.full_name}
+                   </SelectItem>
+                 ))}
+               </SelectContent>
+             </Select>
           </div>
 
           {/* Cart Items */}

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -706,7 +706,7 @@ export default function Services() {
                   {/* Add Product Selection */}
                   <div>
                     <Label htmlFor="addProduct">Add Product to Kit</Label>
-                    <Select value="" onValueChange={addKitItem}>
+                    <Select value={undefined} onValueChange={addKitItem}>
                       <SelectTrigger>
                         <SelectValue placeholder="Select a product to add..." />
                       </SelectTrigger>


### PR DESCRIPTION
Fixes Radix UI `SelectItem` error by replacing empty string values with valid alternatives.

The Radix UI `Select` component throws an error if a `SelectItem` has an empty string `value` prop, as it reserves empty strings for clearing the selection. This PR introduces a sentinel value (`"__walk_in__"`) for the "Walk-in Customer" option in `POS.tsx` and sets `value={undefined}` for the product selection in `Services.tsx` to resolve this conflict.

---
<a href="https://cursor.com/background-agent?bcId=bc-1194e75f-b1da-485f-ae35-529b0ba39144">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1194e75f-b1da-485f-ae35-529b0ba39144">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

