### PR TITLE
Fix formatMoney undefined error

### DIFF
--- a/src/pages/POS.tsx
+++ b/src/pages/POS.tsx
@@ -13,6 +13,7 @@ import { Plus, Search, ShoppingCart, CreditCard, DollarSign, Package, Trash2, Us
 import { format } from "date-fns";
 import { toast } from "sonner";
 import { createSaleWithFallback } from "@/utils/mockDatabase";
+import { useOrganizationCurrency } from "@/lib/saas/hooks";
 
 interface Product {
   id: string;
@@ -74,6 +75,8 @@ export default function POS() {
   const [isPaymentModalOpen, setIsPaymentModalOpen] = useState(false);
   const [isReceiptModalOpen, setIsReceiptModalOpen] = useState(false);
   const [currentSale, setCurrentSale] = useState<Sale | null>(null);
+
+  const { format: formatMoney } = useOrganizationCurrency();
 
   const [paymentData, setPaymentData] = useState({
     payment_method: "",


### PR DESCRIPTION
Fixes `ReferenceError: formatMoney is not defined` by importing `useOrganizationCurrency` and defining `formatMoney` in `src/pages/POS.tsx`.

---
<a href="https://cursor.com/background-agent?bcId=bc-d9814445-cc60-4baf-a1f4-d16a859bdf99">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d9814445-cc60-4baf-a1f4-d16a859bdf99">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

