### PR TITLE
Fix missing accounts table in appointment fetch

### DIFF
--- a/src/pages/Appointments.tsx
+++ b/src/pages/Appointments.tsx
@@ -116,12 +116,19 @@ export default function Appointments() {
       if (appointmentsRes.error) throw appointmentsRes.error;
       if (staffRes.error) throw staffRes.error;
       if (servicesRes.error) throw servicesRes.error;
-      if ((accountsRes as any).error) throw (accountsRes as any).error;
 
       setAppointments(appointmentsRes.data || []);
       setStaff(staffRes.data || []);
       setServices(servicesRes.data || []);
-      setAccounts(((accountsRes as any).data || []) as Array<{ id: string; account_code: string; account_name: string }>);
+
+      const accErr = (accountsRes as any)?.error;
+      const accData = (accountsRes as any)?.data;
+      if (accErr) {
+        console.warn('Accounts fetch failed, continuing without accounts', accErr);
+        setAccounts([]);
+      } else {
+        setAccounts((accData || []) as Array<{ id: string; account_code: string; account_name: string }>);
+      }
 
       // Fetch appointment services for the loaded appointments
       const appointmentIds = (appointmentsRes.data || []).map(a => a.id);


### PR DESCRIPTION
Prevent Appointments page from crashing if the `public.accounts` table is missing.

The Appointments page previously failed to load if the `public.accounts` table was not found in the database schema cache. This change makes the page more resilient by logging a warning and continuing to load other appointment data, rather than throwing an error and preventing the page from rendering. The underlying database issue still needs to be resolved by applying the necessary migrations.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf33d337-7554-4127-9cdc-bdcd7465539d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cf33d337-7554-4127-9cdc-bdcd7465539d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

