### PR TITLE
Fix service selection for appointment booking

### DIFF
--- a/src/pages/Appointments.tsx
+++ b/src/pages/Appointments.tsx
@@ -802,7 +802,7 @@ export default function Appointments() {
                             <SelectTrigger>
                               <SelectValue placeholder="Select Service" />
                             </SelectTrigger>
-                            <SelectContent>
+                            <SelectContent className="z-[100]">
                               {services.map((service) => (
                                 <SelectItem key={service.id} value={service.id}>
                                   {service.name} - ${service.price}
@@ -820,7 +820,7 @@ export default function Appointments() {
                             <SelectTrigger>
                               <SelectValue placeholder="Assign Staff" />
                             </SelectTrigger>
-                            <SelectContent>
+                            <SelectContent className="z-[100]">
                               {staff.map((member) => (
                                 <SelectItem key={member.id} value={member.id}>
                                   {member.full_name}


### PR DESCRIPTION
Adjust z-index of service and staff dropdowns to fix selection issues within the appointment modal.

The dropdown content for service and staff selection was rendering behind the modal overlay, making it unclickable. Increasing the `z-index` ensures they appear above the overlay and are interactive.

---
<a href="https://cursor.com/background-agent?bcId=bc-18e942c5-a69b-4736-933b-e15333d57b7e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-18e942c5-a69b-4736-933b-e15333d57b7e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

