### PR TITLE
Fix appointment save error on edit

### DIFF
--- a/src/pages/Appointments.tsx
+++ b/src/pages/Appointments.tsx
@@ -455,9 +455,11 @@ export default function Appointments() {
       };
 
       if (editingAppointment) {
+        // Do not attempt to update organization_id to avoid schema mismatches
+        const { organization_id, ...updatePayload } = appointmentPayload;
         const { error: updateError } = await supabase
           .from("appointments")
-          .update(appointmentPayload)
+          .update(updatePayload)
           .eq("id", editingAppointment.id);
         if (updateError) throw updateError;
 
@@ -560,8 +562,8 @@ export default function Appointments() {
       fetchData();
       resetForm();
       setIsModalOpen(false);
-    } catch (error) {
-      toast.error("Error saving appointment");
+    } catch (error: any) {
+      toast.error(error?.message ? `Error saving appointment: ${error.message}` : "Error saving appointment");
       console.error(error);
     }
   };


### PR DESCRIPTION
Fixes 'Error saving appointment' when editing by preventing `organization_id` from being updated and improving error messages.

The previous edit flow sent the `organization_id` column during updates, which could lead to errors in environments where the `appointments` table schema does not include this column or due to specific Row Level Security (RLS) policies.

---
<a href="https://cursor.com/background-agent?bcId=bc-a33a0936-fb78-45f2-be23-edcaea53fc08">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a33a0936-fb78-45f2-be23-edcaea53fc08">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

