### PR TITLE
Fix organization currency and country persistence

### DIFF
--- a/src/lib/saas/context.tsx
+++ b/src/lib/saas/context.tsx
@@ -373,13 +373,23 @@ export const SaasProvider: React.FC<{ children: React.ReactNode }> = ({ children
       )
       dispatch({ type: 'SET_ORGANIZATIONS', payload: updatedOrgs })
 
+      // Invalidate cached organizations so fresh data (including currency/country) is fetched next time
+      try {
+        if (state.user) {
+          const cacheKey = createCacheKey(CACHE_KEYS.USER_ORGANIZATIONS, state.user.id)
+          CacheService.delete(cacheKey)
+        }
+      } catch (e) {
+        console.warn('Failed to invalidate organizations cache:', e)
+      }
+
       toast.success('Organization updated successfully!')
       return updatedOrg
     } catch (error) {
       handleError(error, 'Failed to update organization')
       throw error
     }
-  }, [state.organization, state.organizations, handleError])
+  }, [state.organization, state.organizations, state.user, handleError])
 
   // User management actions
   const inviteUser = useCallback(async (email: string, role: UserRole): Promise<UserInvitation> => {

--- a/src/pages/ServiceView.tsx
+++ b/src/pages/ServiceView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
+import { useOrganizationCurrency } from "@/lib/saas/hooks";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -85,8 +86,8 @@ export default function ServiceView() {
     }
   }, [id]);
 
-  const formatPrice = (price: number) =>
-    new Intl.NumberFormat("en-KE", { style: "currency", currency: "KES" }).format(price);
+  const { format: formatCurrency } = useOrganizationCurrency()
+  const formatPrice = (price: number) => formatCurrency(price)
 
   const formatDuration = (minutes: number) => {
     const h = Math.floor(minutes / 60);

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -195,6 +195,9 @@ phone: "+1 (555) 123-4567",
         },
       } as any)
       toast.success("Company settings updated successfully");
+      // Ensure local UI reflects saved country and currency immediately
+      setSelectedCountryCode(selectedCountryCode)
+      setSelectedCurrencyId(selectedCurrencyId)
     } catch (err) {
       console.error(err)
       toast.error("Failed to update organization");


### PR DESCRIPTION
Ensure selected organization currency and country persist across sessions and are correctly applied in price formatting.

Previously, updates to organization currency and country were not consistently reflected due to stale data in the cache. This PR invalidates the cache after an organization update, ensuring the latest settings are always loaded. It also replaces hardcoded currency formatting with a dynamic approach based on the organization's selected currency.

---
<a href="https://cursor.com/background-agent?bcId=bc-f6796108-d7f6-4292-8c4b-37d953a9e84c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f6796108-d7f6-4292-8c4b-37d953a9e84c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

