### PR TITLE
Fix vertical tabs on report listing page

### DIFF
--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -376,7 +376,7 @@ const Reports = () => {
         </div>
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
           <aside className="lg:col-span-3 xl:col-span-2 lg:sticky lg:top-24 self-start max-h-[calc(100vh-7rem)] overflow-y-auto">
-            <TabsList className="flex flex-col w-full items-stretch rounded-xl border bg-card shadow-sm p-1 gap-1">
+            <TabsList className="flex flex-col w-full items-stretch rounded-xl border bg-card shadow-sm p-1 gap-1 h-auto">
               <TabsTrigger value="overview" className="justify-start flex items-center gap-2 rounded-md data-[state=active]:bg-muted">
                 <Activity className="w-4 h-4" /> Overview
               </TabsTrigger>


### PR DESCRIPTION
Make vertical tabs on the Reports page always visible by overriding the fixed height of the `TabsList` component.

---
<a href="https://cursor.com/background-agent?bcId=bc-d763dc9f-6fd6-4421-a2ad-e2bbcfc8e93c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d763dc9f-6fd6-4421-a2ad-e2bbcfc8e93c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

