### PR TITLE
Fix company settings not saving

### DIFF
--- a/src/lib/saas/utils.ts
+++ b/src/lib/saas/utils.ts
@@ -330,15 +330,46 @@ export function validateSlug(slug: string): { valid: boolean; message?: string }
  */
 
 export function sanitizeOrganizationData(data: any) {
-  return {
-    name: data.name?.trim(),
-    slug: data.slug?.toLowerCase().trim(),
-    domain: data.domain?.toLowerCase().trim() || null,
-    logo_url: data.logo_url?.trim() || null,
-    currency_id: data.currency_id || null,
-    settings: data.settings || {},
-    metadata: data.metadata || {},
+  const updates: any = {}
+
+  if ('name' in data) {
+    updates.name = typeof data.name === 'string' ? data.name.trim() : data.name
   }
+
+  if ('slug' in data) {
+    updates.slug = typeof data.slug === 'string' ? data.slug.toLowerCase().trim() : data.slug
+  }
+
+  if ('domain' in data) {
+    const domainVal = data.domain
+    updates.domain = domainVal === null
+      ? null
+      : (typeof domainVal === 'string' ? domainVal.toLowerCase().trim() : domainVal)
+  }
+
+  if ('logo_url' in data) {
+    const logoVal = data.logo_url
+    updates.logo_url = logoVal === null
+      ? null
+      : (typeof logoVal === 'string' ? logoVal.trim() : logoVal)
+  }
+
+  if ('currency_id' in data) {
+    // Allow explicit null to clear the association
+    updates.currency_id = data.currency_id ?? null
+  }
+
+  if ('settings' in data) {
+    // If settings provided, use it as-is (caller should merge with existing if needed)
+    // Default to {} only if explicitly passed as undefined/null-like
+    updates.settings = data.settings ?? {}
+  }
+
+  if ('metadata' in data) {
+    updates.metadata = data.metadata ?? {}
+  }
+
+  return updates
 }
 
 export function formatCurrency(amount: number, currency: string = 'USD'): string {


### PR DESCRIPTION
Update `sanitizeOrganizationData` to prevent unintended overwrites of organization fields.

Previously, fields like `settings`, `currency_id`, `domain`, and `logo_url` were implicitly set to default values (e.g., `{}`, `null`) if not provided in the update payload, leading to data loss. This change ensures only explicitly provided fields are updated.

---
<a href="https://cursor.com/background-agent?bcId=bc-838ede99-70d3-4234-8e10-17271e1c7354">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-838ede99-70d3-4234-8e10-17271e1c7354">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

