### PR TITLE
Add foreign currency pricing for subscriptions

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -273,6 +273,33 @@ export type Database = {
         }
         Relationships: []
       }
+      currency_rates: {
+        Row: {
+          id: string
+          code: string
+          rate: number
+          source: string | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          code: string
+          rate: number
+          source?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          code?: string
+          rate?: number
+          source?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       expenses: {
         Row: {
           amount: number

--- a/src/pages/UpgradePlan.tsx
+++ b/src/pages/UpgradePlan.tsx
@@ -6,11 +6,13 @@ import { supabase } from "@/integrations/supabase/client";
 import { useSaas } from "@/lib/saas/context";
 import { useEffect, useState } from "react";
 import { SubscriptionService } from "@/lib/saas/services";
+import { useOrganizationCurrency } from "@/lib/saas/hooks";
 
 export default function UpgradePlan() {
   const navigate = useNavigate();
   const { organization } = useSaas();
   const [plans, setPlans] = useState<any[]>([])
+  const { formatUsdCents } = useOrganizationCurrency()
   const [saving, setSaving] = useState<string | null>(null)
 
   useEffect(() => {
@@ -46,7 +48,7 @@ export default function UpgradePlan() {
             <div key={p} className="border rounded-md p-4 space-y-3">
               <div className="text-lg font-semibold capitalize">{p.name}</div>
               <div className="text-sm text-muted-foreground">{p.slug}</div>
-              <div className="text-xl font-bold">${(p.price_monthly / 100).toFixed(0)}/mo</div>
+                             <div className="text-xl font-bold">{formatUsdCents(p.price_monthly)}/mo</div>
               <Button variant="outline" disabled={!!saving} onClick={() => handleSelect(p.id)}>{saving === p.id ? 'Saving...' : 'Select'}</Button>
             </div>
           ))}

--- a/src/pages/admin/AdminSubscriptionPlans.tsx
+++ b/src/pages/admin/AdminSubscriptionPlans.tsx
@@ -16,6 +16,7 @@ import SuperAdminLayout from "@/components/layout/SuperAdminLayout";
 import { FEATURE_CATEGORIES, FEATURE_LABELS } from "@/lib/features";
 import { useSaas } from "@/lib/saas/context";
 import { SuperAdminService } from "@/lib/saas/services";
+import { useOrganizationCurrency } from "@/lib/saas/hooks";
 
 interface SubscriptionPlan {
   id: string;
@@ -53,7 +54,8 @@ const AdminSubscriptionPlans = () => {
   const [searchTerm, setSearchTerm] = useState("");
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
-  const [selectedPlan, setSelectedPlan] = useState<SubscriptionPlan | null>(null);
+     const [selectedPlan, setSelectedPlan] = useState<SubscriptionPlan | null>(null);
+   const { formatUsdCents } = useOrganizationCurrency()
   const [newPlan, setNewPlan] = useState<NewSubscriptionPlan>({
     name: "",
     slug: "",
@@ -302,9 +304,7 @@ const AdminSubscriptionPlans = () => {
     plan.description?.toLowerCase().includes(searchTerm.toLowerCase())
   );
 
-  const formatPrice = (priceInCents: number) => {
-    return `$${(priceInCents / 100).toFixed(2)}`;
-  };
+
 
   return (
     <SuperAdminLayout>
@@ -398,8 +398,8 @@ const AdminSubscriptionPlans = () => {
                           <div className="text-sm text-gray-500">{plan.slug}</div>
                         </div>
                       </TableCell>
-                      <TableCell>{formatPrice(plan.price_monthly)}</TableCell>
-                      <TableCell>{formatPrice(plan.price_yearly)}</TableCell>
+                                             <TableCell>{formatUsdCents(plan.price_monthly)}</TableCell>
+                                             <TableCell>{formatUsdCents(plan.price_yearly)}</TableCell>
                       <TableCell>{plan.max_users || 'Unlimited'}</TableCell>
                       <TableCell>{plan.max_locations || 'Unlimited'}</TableCell>
                       <TableCell>

--- a/supabase/migrations/20250810143000_add_currency_rates.sql
+++ b/supabase/migrations/20250810143000_add_currency_rates.sql
@@ -1,0 +1,81 @@
+-- Currency rates for converting from USD to other currencies
+-- One row per target currency code; rate means 1 USD = rate <code>
+
+CREATE TABLE IF NOT EXISTS public.currency_rates (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  code text NOT NULL UNIQUE,
+  rate numeric(18,6) NOT NULL,
+  source text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Enable RLS
+ALTER TABLE public.currency_rates ENABLE ROW LEVEL SECURITY;
+
+-- Policies: public read, super admins manage
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies 
+    WHERE schemaname = 'public' AND tablename = 'currency_rates' AND policyname = 'Public can SELECT currency rates'
+  ) THEN
+    CREATE POLICY "Public can SELECT currency rates"
+    ON public.currency_rates
+    FOR SELECT
+    USING (true);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies 
+    WHERE schemaname = 'public' AND tablename = 'currency_rates' AND policyname = 'Super admins can INSERT currency rates'
+  ) THEN
+    CREATE POLICY "Super admins can INSERT currency rates"
+    ON public.currency_rates
+    FOR INSERT
+    WITH CHECK (public.is_super_admin(auth.uid()));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies 
+    WHERE schemaname = 'public' AND tablename = 'currency_rates' AND policyname = 'Super admins can UPDATE currency rates'
+  ) THEN
+    CREATE POLICY "Super admins can UPDATE currency rates"
+    ON public.currency_rates
+    FOR UPDATE
+    USING (public.is_super_admin(auth.uid()))
+    WITH CHECK (public.is_super_admin(auth.uid()));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies 
+    WHERE schemaname = 'public' AND tablename = 'currency_rates' AND policyname = 'Super admins can DELETE currency rates'
+  ) THEN
+    CREATE POLICY "Super admins can DELETE currency rates"
+    ON public.currency_rates
+    FOR DELETE
+    USING (public.is_super_admin(auth.uid()));
+  END IF;
+END $$;
+
+-- Updated at trigger
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'update_currency_rates_updated_at'
+  ) THEN
+    CREATE TRIGGER update_currency_rates_updated_at
+    BEFORE UPDATE ON public.currency_rates
+    FOR EACH ROW
+    EXECUTE FUNCTION public.update_updated_at_column();
+  END IF;
+END $$;
+
+-- Seed a few default rates if missing (rates are illustrative; update in admin as needed)
+INSERT INTO public.currency_rates (code, rate, source)
+VALUES
+  ('USD', 1.000000, 'static seed'),
+  ('KES', 129.000000, 'static seed'),
+  ('EUR', 0.920000, 'static seed'),
+  ('GBP', 0.780000, 'static seed')
+ON CONFLICT (code) DO NOTHING;


### PR DESCRIPTION
Adds foreign currency pricing support by introducing exchange rates and displaying subscription plan prices in the organization's selected currency.

Subscription plans were previously priced in USD cents and displayed without currency conversion. This PR introduces a `currency_rates` table to store exchange rates relative to USD, extends the `useOrganizationCurrency` hook to fetch the organization's selected currency and its rate, and updates the Upgrade Plan and Admin Subscription Plans pages to convert and display prices in the organization's local currency.

---
<a href="https://cursor.com/background-agent?bcId=bc-6d283cac-5218-42bd-828d-36f72afdd218">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6d283cac-5218-42bd-828d-36f72afdd218">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

