### PR TITLE
Fix subscription package currency to cents

### DIFF
--- a/src/lib/saas/hooks.ts
+++ b/src/lib/saas/hooks.ts
@@ -444,7 +444,11 @@ export const useOrganizationCurrency = () => {
       const n = typeof amount === 'number' ? amount : 0
       const decimals = opts?.decimals ?? 2
       const sym = currency?.symbol ?? '$'
-      return `${sym}${n.toFixed(decimals)}`
+      const formatted = new Intl.NumberFormat('en-US', {
+        minimumFractionDigits: decimals,
+        maximumFractionDigits: decimals,
+      }).format(n)
+      return `${sym}${formatted}`
     },
     [currency]
   )
@@ -463,8 +467,8 @@ export const useOrganizationCurrency = () => {
   const formatUsdCents = useCallback(
     (usdCents: number | null | undefined) => {
       const code = currency?.code ?? 'USD'
-      // Default decimals: 0 for KES/JPY-like, 2 otherwise
-      const zeroDecimalCodes = new Set(['KES', 'JPY', 'KRW'])
+      // Default decimals: 0 for truly zero-decimal currencies only
+      const zeroDecimalCodes = new Set(['JPY', 'KRW'])
       const decimals = zeroDecimalCodes.has(code) ? 0 : 2
       const major = convertUsdCentsToOrgMajor(usdCents)
       return format(major, { decimals })

--- a/src/pages/BillingHistory.tsx
+++ b/src/pages/BillingHistory.tsx
@@ -7,7 +7,7 @@ import { useSaas } from "@/lib/saas/context";
 import { useEffect, useState } from "react";
 
 export default function BillingHistory() {
-  const { symbol } = useOrganizationCurrency();
+  const { symbol, format } = useOrganizationCurrency();
   const { organization } = useSaas();
   const [rows, setRows] = useState<any[]>([])
 
@@ -44,7 +44,7 @@ export default function BillingHistory() {
                 <TableRow key={r.id}>
                   <TableCell>{new Date(r.created_at).toLocaleDateString()}</TableCell>
                   <TableCell>{r.description}</TableCell>
-                  <TableCell className="text-right">{symbol}{Number(r.amount).toFixed(2)}</TableCell>
+                  <TableCell className="text-right">{format(Number(r.amount))}</TableCell>
                   <TableCell><Badge variant="outline">{r.status}</Badge></TableCell>
                 </TableRow>
               ))}


### PR DESCRIPTION
Corrects subscription package listing currency display to show cents with proper formatting and decimal places.

The previous implementation incorrectly treated KES as a zero-decimal currency and lacked proper thousand separators, leading to prices appearing as whole thousands. This PR updates `useOrganizationCurrency` to use `Intl.NumberFormat` for accurate formatting and ensures KES displays two decimal places.

---
<a href="https://cursor.com/background-agent?bcId=bc-57722895-5d3d-4381-a1af-8e480a7c97fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-57722895-5d3d-4381-a1af-8e480a7c97fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

