### PR TITLE
Fix sidebar collapse display issue

### DIFF
--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -261,7 +261,7 @@ export function AppSidebar() {
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <div className="h-7 w-7 rounded-md bg-gradient-to-br from-blue-500 to-violet-600" />
-              <span className="font-semibold">SalonFlow</span>
+              <span className="font-semibold group-data-[collapsible=icon]:hidden">SalonFlow</span>
             </div>
             <SidebarTrigger className="hidden md:inline-flex" />
           </div>
@@ -294,7 +294,7 @@ export function AppSidebar() {
                       >
                         <item.icon className="w-4 h-4" />
                         <span className="flex-1">{item.title}</span>
-                        <div className="flex items-center gap-1">
+                        <div className="flex items-center gap-1 group-data-[collapsible=icon]:hidden">
                           {!isAvailable && <Lock className="w-3 h-3 text-slate-400" />}
                           {isOpen ? (
                             <ChevronDown className="w-4 h-4" />

--- a/src/components/layout/SuperAdminSidebar.tsx
+++ b/src/components/layout/SuperAdminSidebar.tsx
@@ -150,7 +150,7 @@ export function SuperAdminSidebar() {
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2 text-purple-800">
               <Crown className="h-5 w-5" />
-              <span className="font-semibold">Admin Panel</span>
+              <span className="font-semibold group-data-[collapsible=icon]:hidden">Admin Panel</span>
             </div>
             <SidebarTrigger className="hidden md:inline-flex text-purple-700" />
           </div>
@@ -179,11 +179,13 @@ export function SuperAdminSidebar() {
                       >
                         <item.icon className="w-4 h-4" />
                         <span className="flex-1">{item.title}</span>
-                        {isOpen ? (
-                          <ChevronDown className="w-4 h-4" />
-                        ) : (
-                          <ChevronRight className="w-4 h-4" />
-                        )}
+                        <div className="group-data-[collapsible=icon]:hidden">
+                          {isOpen ? (
+                            <ChevronDown className="w-4 h-4" />
+                          ) : (
+                            <ChevronRight className="w-4 h-4" />
+                          )}
+                        </div>
                       </SidebarMenuButton>
                       {isOpen && (
                         <SidebarMenuSub>


### PR DESCRIPTION
Hide sidebar text and chevrons in icon-collapsed mode to fix display issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-c43d99a6-5740-4af2-b754-ac09acdc3a78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c43d99a6-5740-4af2-b754-ac09acdc3a78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

