### PR TITLE
Fix saas provider initialization error

### DIFF
--- a/src/lib/saas/context.tsx
+++ b/src/lib/saas/context.tsx
@@ -150,6 +150,52 @@ export const SaasProvider: React.FC<{ children: React.ReactNode }> = ({ children
     dispatch({ type: 'CLEAR_ERROR' })
   }, [])
 
+  // Set active organization
+  const setActiveOrganization = useCallback(async (
+    organization: Organization, 
+    role: UserRole, 
+    silent = false
+  ) => {
+   try {
+     dispatch({ type: 'SET_ORGANIZATION', payload: organization })
+     dispatch({ type: 'SET_ORGANIZATION_ROLE', payload: role })
+     localStorage.setItem(STORAGE_KEYS.ACTIVE_ORGANIZATION, organization.id)
+
+     // Load subscription data
+     try {
+       const subscription = await SubscriptionService.getOrganizationSubscription(organization.id)
+       dispatch({ type: 'SET_SUBSCRIPTION', payload: subscription })
+       
+       if (subscription?.subscription_plans) {
+         dispatch({ type: 'SET_SUBSCRIPTION_PLAN', payload: subscription.subscription_plans })
+       }
+     } catch (error) {
+       console.error('Error loading subscription:', error)
+       // Don't throw, just set null
+       dispatch({ type: 'SET_SUBSCRIPTION', payload: null })
+       dispatch({ type: 'SET_SUBSCRIPTION_PLAN', payload: null })
+     }
+
+     // Load usage metrics
+     if (!silent) {
+       try {
+         const metrics = await UsageService.getUsageMetrics(organization.id)
+         dispatch({ type: 'SET_USAGE_METRICS', payload: metrics })
+       } catch (error) {
+         console.error('Error loading usage metrics:', error)
+       }
+     }
+
+     // Track organization switch
+     AnalyticsService.trackEvent(organization.id, 'organization_switched', {
+       organization_name: organization.name,
+       user_role: role,
+     })
+   } catch (error) {
+     handleError(error, 'Failed to switch organization')
+   }
+ }, [handleError])
+
   // Load user organizations
   const loadUserOrganizations = useCallback(async (userId: string, silent = false) => {
     try {
@@ -278,52 +324,6 @@ export const SaasProvider: React.FC<{ children: React.ReactNode }> = ({ children
       }
     }
         }, [handleError, setActiveOrganization])
-  
-   // Set active organization
-   const setActiveOrganization = useCallback(async (
-     organization: Organization, 
-     role: UserRole, 
-     silent = false
-   ) => {
-    try {
-      dispatch({ type: 'SET_ORGANIZATION', payload: organization })
-      dispatch({ type: 'SET_ORGANIZATION_ROLE', payload: role })
-      localStorage.setItem(STORAGE_KEYS.ACTIVE_ORGANIZATION, organization.id)
-
-      // Load subscription data
-      try {
-        const subscription = await SubscriptionService.getOrganizationSubscription(organization.id)
-        dispatch({ type: 'SET_SUBSCRIPTION', payload: subscription })
-        
-        if (subscription?.subscription_plans) {
-          dispatch({ type: 'SET_SUBSCRIPTION_PLAN', payload: subscription.subscription_plans })
-        }
-      } catch (error) {
-        console.error('Error loading subscription:', error)
-        // Don't throw, just set null
-        dispatch({ type: 'SET_SUBSCRIPTION', payload: null })
-        dispatch({ type: 'SET_SUBSCRIPTION_PLAN', payload: null })
-      }
-
-      // Load usage metrics
-      if (!silent) {
-        try {
-          const metrics = await UsageService.getUsageMetrics(organization.id)
-          dispatch({ type: 'SET_USAGE_METRICS', payload: metrics })
-        } catch (error) {
-          console.error('Error loading usage metrics:', error)
-        }
-      }
-
-      // Track organization switch
-      AnalyticsService.trackEvent(organization.id, 'organization_switched', {
-        organization_name: organization.name,
-        user_role: role,
-      })
-    } catch (error) {
-      handleError(error, 'Failed to switch organization')
-    }
-  }, [handleError])
 
   // Organization actions
   const switchOrganization = useCallback(async (organizationId: string) => {


### PR DESCRIPTION
Reorder hook definitions in `SaasProvider` to fix `ReferenceError: Cannot access 'setActiveOrganization' before initialization`.

The `loadUserOrganizations` hook attempted to access `setActiveOrganization` in its dependency array before `setActiveOrganization` was initialized, leading to a temporal dead zone error. Moving `setActiveOrganization` above `loadUserOrganizations` resolves this initialization order issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba4881ce-305e-4c3b-80d6-4c98d0d1c712">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba4881ce-305e-4c3b-80d6-4c98d0d1c712">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

