### PR TITLE
Fix appointment viewing and job card creation

### DIFF
--- a/src/pages/CreateJobCard.tsx
+++ b/src/pages/CreateJobCard.tsx
@@ -277,6 +277,13 @@ export default function CreateJobCard() {
     fetchInitialData();
   }, []);
 
+  // Once initial data is loaded, if an appointment query param is present, prefill from it
+  useEffect(() => {
+    if (!loading && appointmentId) {
+      loadAppointmentData(appointmentId);
+    }
+  }, [loading, appointmentId, loadAppointmentData]);
+
   // Bridge to allow child step to set serviceStaffMap locally without prop drilling refactors
   useEffect(() => {
     (window as any).__setServiceStaffMap = (map: Record<string, string>) => {


### PR DESCRIPTION
Implement read-only view for appointments and update 'Create Jobcard' to prefill a new job card from an appointment.

The previous "View Appointment" was a non-functional placeholder, and "Create Jobcard" attempted a direct database insertion which was prone to failure due to potential schema mismatches or missing data. This PR provides a functional view and a more robust job card creation flow by navigating to the dedicated creation page with pre-filled data.

---
<a href="https://cursor.com/background-agent?bcId=bc-84e8f60e-4454-4a06-a907-e24c88c671a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-84e8f60e-4454-4a06-a907-e24c88c671a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

