### PR TITLE
Fix saas provider initialization error

### DIFF
--- a/src/lib/saas/context.tsx
+++ b/src/lib/saas/context.tsx
@@ -151,50 +151,50 @@ export const SaasProvider: React.FC<{ children: React.ReactNode }> = ({ children
   }, [])
 
   // Set active organization
-  const setActiveOrganization = useCallback(async (
-    organization: Organization, 
-    role: UserRole, 
+  async function setActiveOrganization(
+    organization: Organization,
+    role: UserRole,
     silent = false
-  ) => {
-   try {
-     dispatch({ type: 'SET_ORGANIZATION', payload: organization })
-     dispatch({ type: 'SET_ORGANIZATION_ROLE', payload: role })
-     localStorage.setItem(STORAGE_KEYS.ACTIVE_ORGANIZATION, organization.id)
+  ) {
+    try {
+      dispatch({ type: 'SET_ORGANIZATION', payload: organization })
+      dispatch({ type: 'SET_ORGANIZATION_ROLE', payload: role })
+      localStorage.setItem(STORAGE_KEYS.ACTIVE_ORGANIZATION, organization.id)
 
-     // Load subscription data
-     try {
-       const subscription = await SubscriptionService.getOrganizationSubscription(organization.id)
-       dispatch({ type: 'SET_SUBSCRIPTION', payload: subscription })
-       
-       if (subscription?.subscription_plans) {
-         dispatch({ type: 'SET_SUBSCRIPTION_PLAN', payload: subscription.subscription_plans })
-       }
-     } catch (error) {
-       console.error('Error loading subscription:', error)
-       // Don't throw, just set null
-       dispatch({ type: 'SET_SUBSCRIPTION', payload: null })
-       dispatch({ type: 'SET_SUBSCRIPTION_PLAN', payload: null })
-     }
+      // Load subscription data
+      try {
+        const subscription = await SubscriptionService.getOrganizationSubscription(organization.id)
+        dispatch({ type: 'SET_SUBSCRIPTION', payload: subscription })
+        
+        if (subscription?.subscription_plans) {
+          dispatch({ type: 'SET_SUBSCRIPTION_PLAN', payload: subscription.subscription_plans })
+        }
+      } catch (error) {
+        console.error('Error loading subscription:', error)
+        // Don't throw, just set null
+        dispatch({ type: 'SET_SUBSCRIPTION', payload: null })
+        dispatch({ type: 'SET_SUBSCRIPTION_PLAN', payload: null })
+      }
 
-     // Load usage metrics
-     if (!silent) {
-       try {
-         const metrics = await UsageService.getUsageMetrics(organization.id)
-         dispatch({ type: 'SET_USAGE_METRICS', payload: metrics })
-       } catch (error) {
-         console.error('Error loading usage metrics:', error)
-       }
-     }
+      // Load usage metrics
+      if (!silent) {
+        try {
+          const metrics = await UsageService.getUsageMetrics(organization.id)
+          dispatch({ type: 'SET_USAGE_METRICS', payload: metrics })
+        } catch (error) {
+          console.error('Error loading usage metrics:', error)
+        }
+      }
 
-     // Track organization switch
-     AnalyticsService.trackEvent(organization.id, 'organization_switched', {
-       organization_name: organization.name,
-       user_role: role,
-     })
-   } catch (error) {
-     handleError(error, 'Failed to switch organization')
-   }
- }, [handleError])
+      // Track organization switch
+      AnalyticsService.trackEvent(organization.id, 'organization_switched', {
+        organization_name: organization.name,
+        user_role: role,
+      })
+    } catch (error) {
+      handleError(error, 'Failed to switch organization')
+    }
+  }
 
   // Load user organizations
   const loadUserOrganizations = useCallback(async (userId: string, silent = false) => {


### PR DESCRIPTION
Fixes "Cannot access 'setActiveOrganization' before initialization" by converting `setActiveOrganization` to a hoisted function declaration.

---
<a href="https://cursor.com/background-agent?bcId=bc-4cf87463-4a4a-402f-be3a-c9b8f7fb8377">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4cf87463-4a4a-402f-be3a-c9b8f7fb8377">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

