### PR TITLE
Fix fetchServices initialization error

### DIFF
--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -170,12 +170,7 @@ export default function Services() {
     }));
   };
 
-    useEffect(() => {
-    fetchServices();
-    fetchAvailableProducts();
-  }, [fetchServices, fetchAvailableProducts]);
- 
-   const fetchServices = useCallback(async () => {
+  const fetchServices = useCallback(async () => {
     try {
       setLoading(true);
       const { data, error } = await supabase
@@ -219,6 +214,11 @@ export default function Services() {
       console.error("Error fetching products:", error);
     }
   }, []);
+
+  useEffect(() => {
+    fetchServices();
+    fetchAvailableProducts();
+  }, [fetchServices, fetchAvailableProducts]);
 
   const fetchServiceKits = async (serviceId: string) => {
     try {


### PR DESCRIPTION
Moves `useEffect` in `Services.tsx` to resolve a `ReferenceError` caused by accessing functions before initialization.

The `useEffect` hook was attempting to call `fetchServices` and `fetchAvailableProducts` before their `const` declarations were processed, leading to a temporal dead zone error. Moving the `useEffect` after these declarations ensures they are initialized first.

---
<a href="https://cursor.com/background-agent?bcId=bc-a344dafa-8d6b-4aef-815c-dbe5d12d50ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a344dafa-8d6b-4aef-815c-dbe5d12d50ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

