### PR TITLE
Fix staff fetch initialization error

### DIFF
--- a/src/pages/Staff.tsx
+++ b/src/pages/Staff.tsx
@@ -123,12 +123,8 @@ export default function Staff() {
     hire_date: "",
     is_active: true,
   });
-
-    useEffect(() => {
-    fetchStaff();
-  }, [fetchStaff]);
  
-   const fetchStaff = useCallback(async () => {
+  const fetchStaff = useCallback(async () => {
     try {
       setLoading(true);
       const { data, error } = await supabase
@@ -149,6 +145,10 @@ export default function Staff() {
       setLoading(false);
     }
   }, [toast]);
+
+  useEffect(() => {
+    fetchStaff();
+  }, [fetchStaff]);
 
   const refreshData = async () => {
     try {


### PR DESCRIPTION
Reordered `fetchStaff` and `useEffect` in `Staff.tsx` to resolve a "cannot access before initialization" error.

The `useEffect` hook was referencing `fetchStaff` in its dependency array before `fetchStaff` was declared, leading to a temporal dead zone error. Moving the `fetchStaff` declaration above the `useEffect` resolves this issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f0cb9d4-03a4-48e8-abc8-056d5abe7e78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6f0cb9d4-03a4-48e8-abc8-056d5abe7e78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

