### PR TITLE
Fix appointments not displaying on client profile

### DIFF
--- a/src/pages/ClientProfile.tsx
+++ b/src/pages/ClientProfile.tsx
@@ -136,8 +136,9 @@ export default function ClientProfile() {
           id, appointment_date, appointment_time, service_name, status, price,
           staff:staff_id (full_name)
         `)
-        .eq("customer_name", clientData?.full_name)
-        .order("appointment_date", { ascending: false });
+        .eq("client_id", id)
+        .order("appointment_date", { ascending: false })
+        .order("appointment_time", { ascending: false });
 
       if (appointmentsError) throw appointmentsError;
       setAppointments((appointmentsData || []).map(app => ({


### PR DESCRIPTION
Fixes appointments not displaying on client profile by filtering by `client_id` instead of `customer_name`.

The previous query used `customer_name` for filtering appointments, which was unreliable and did not match how appointments are created (which use `client_id`). This change ensures appointments are correctly linked and displayed on the client profile page.

---
<a href="https://cursor.com/background-agent?bcId=bc-df1b340f-1297-4c66-90c8-c33958e04aa8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df1b340f-1297-4c66-90c8-c33958e04aa8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

