### PR TITLE
Fix today's appointments not displaying on jobcard

### DIFF
--- a/src/pages/CreateJobCard.tsx
+++ b/src/pages/CreateJobCard.tsx
@@ -205,7 +205,7 @@ export default function CreateJobCard() {
         supabase.from("staff").select("*").eq("is_active", true),
         supabase.from("clients").select("*"),
         supabase.from("services").select("*").eq("is_active", true),
-        supabase.from("appointments").select("*").eq("status", "confirmed").gte("appointment_date", new Date().toISOString().split('T')[0])
+        supabase.from("appointments").select("*").gte("appointment_date", format(new Date(), 'yyyy-MM-dd'))
       ]);
 
       if (staffRes.data) setStaff(staffRes.data);
@@ -736,7 +736,7 @@ function StepAppointmentClient({
   );
 
   const todayAppointments = appointments.filter(apt => 
-    apt.appointment_date === new Date().toISOString().split('T')[0]
+    apt.appointment_date === format(new Date(), 'yyyy-MM-dd')
   );
 
   return (


### PR DESCRIPTION
Display today's appointments on the create jobcard page by fetching all relevant statuses and fixing date comparison for timezone issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-0cc5945f-9667-492c-9f4c-2512fecd63b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0cc5945f-9667-492c-9f4c-2512fecd63b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

