### PR TITLE
Check for missing public receipts table

### DIFF
--- a/supabase/migrations/20250809120000_reload_schema_after_receipts.sql
+++ b/supabase/migrations/20250809120000_reload_schema_after_receipts.sql
@@ -1,0 +1,5 @@
+-- Ensure PostgREST reloads schema after creating receipts-related tables
+-- Fixes: "Could not find the table 'public.receipts' in the schema cache"
+DO $$ BEGIN
+  PERFORM pg_notify('pgrst', 'reload schema');
+END $$;


### PR DESCRIPTION
Add migration to reload PostgREST schema to resolve 'table not found' errors.

The "Could not find the table 'public.receipts' in the schema cache" error occurs because PostgREST's schema cache is stale after the `public.receipts` table is created. This migration explicitly notifies PostgREST to reload its schema, ensuring the new table is recognized.

---
<a href="https://cursor.com/background-agent?bcId=bc-5254b519-e628-4eea-9532-27bbc004036c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5254b519-e628-4eea-9532-27bbc004036c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

