### PR TITLE
Fix purchase product lookup bug

### DIFF
--- a/src/pages/Purchases.tsx
+++ b/src/pages/Purchases.tsx
@@ -139,7 +139,7 @@ export default function Purchases() {
       const { data, error } = await supabase
         .from("inventory_items")
         .select("id, name, type")
-        .eq("type", "goods")
+        .eq("type", "good")
         .eq("is_active", true)
         .order("name");
 


### PR DESCRIPTION
Fix product lookup in Create New Purchase by correcting the inventory item type filter.

The previous filter `type = "goods"` did not match any inventory items, preventing products from appearing in the purchase item selector.

---
<a href="https://cursor.com/background-agent?bcId=bc-284d805e-0810-46c0-9140-c3080b98e66f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-284d805e-0810-46c0-9140-c3080b98e66f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

