### PR TITLE
Update stock and purchase status on item receipt

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,6 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.19"
+    "vite": "5.4.19"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,7 +217,7 @@ importers:
         specifier: ^8.0.1
         version: 8.39.0(eslint@9.33.0(jiti@1.21.7))(typescript@5.9.2)
       vite:
-        specifier: ^5.4.19
+        specifier: 5.4.19
         version: 5.4.19(@types/node@22.17.1)
 
 packages:

--- a/src/pages/Purchases.tsx
+++ b/src/pages/Purchases.tsx
@@ -216,6 +216,73 @@ export default function Purchases() {
     }
   };
 
+  // Undo Receiving: reverse inventory levels and clear received quantities
+  const undoReceiving = async (purchaseId: string) => {
+    try {
+      const { data: purchase, error: pErr } = await supabase
+        .from("purchases")
+        .select("id, location_id, status")
+        .eq("id", purchaseId)
+        .single();
+      if (pErr) throw pErr;
+
+      if (!purchase?.location_id) {
+        toast({ title: "Nothing to undo", description: "This purchase has no receiving location set.", variant: "destructive" });
+        return;
+      }
+
+      const { data: items, error: iErr } = await supabase
+        .from("purchase_items")
+        .select("id, item_id, received_quantity")
+        .eq("purchase_id", purchaseId);
+      if (iErr) throw iErr;
+
+      let anyReceived = false;
+      for (const it of items || []) {
+        const receivedQty = Number(it.received_quantity || 0);
+        if (receivedQty > 0) {
+          anyReceived = true;
+          const { data: levels } = await supabase
+            .from("inventory_levels")
+            .select("id, quantity")
+            .eq("item_id", it.item_id)
+            .eq("location_id", purchase.location_id)
+            .limit(1);
+
+          if (levels && levels.length > 0) {
+            const level = levels[0];
+            const newQty = Math.max(0, Number(level.quantity || 0) - receivedQty);
+            await supabase
+              .from("inventory_levels")
+              .update({ quantity: newQty })
+              .eq("id", level.id);
+          }
+
+          await supabase
+            .from("purchase_items")
+            .update({ received_quantity: 0 })
+            .eq("id", it.id);
+        }
+      }
+
+      if (!anyReceived) {
+        toast({ title: "No received items", description: "There are no received items to undo.", variant: "destructive" });
+        return;
+      }
+
+      await supabase
+        .from("purchases")
+        .update({ status: "pending", location_id: null })
+        .eq("id", purchaseId);
+
+      toast({ title: "Receiving removed", description: "Inventory and received quantities have been reverted." });
+      fetchPurchases();
+    } catch (err) {
+      console.error(err);
+      toast({ title: "Error", description: "Failed to undo receiving", variant: "destructive" });
+    }
+  };
+
   const generatePurchaseNumber = () => {
     const timestamp = Date.now().toString().slice(-6);
     return `PUR-${timestamp}`;
@@ -449,46 +516,17 @@ export default function Purchases() {
   const handleDelete = async (id: string) => {
     if (confirm("Are you sure you want to delete this purchase?")) {
       try {
-        // Ensure only unpaid (not fully received) purchases can be deleted
-        const { data: purchase, error: fetchErr } = await supabase
-          .from("purchases")
-          .select("id, status, location_id")
-          .eq("id", id)
-          .single();
-        if (fetchErr) throw fetchErr;
-
-        if (!purchase || purchase.status === 'received') {
-          toast({ title: "Not allowed", description: "Received purchases cannot be deleted.", variant: "destructive" });
-          return;
-        }
-
+        // Check if any items have been received; if so, block deletion until undone
         const { data: items, error: itemsErr } = await supabase
           .from("purchase_items")
-          .select("item_id, received_quantity")
+          .select("received_quantity")
           .eq("purchase_id", id);
         if (itemsErr) throw itemsErr;
 
-        // Reverse any received inventory for partial receipts at the purchase location
-        if (purchase.location_id) {
-          for (const it of (items || [])) {
-            const receivedQty = Number(it.received_quantity || 0);
-            if (receivedQty > 0) {
-              const { data: levels } = await supabase
-                .from("inventory_levels")
-                .select("id, quantity")
-                .eq("item_id", it.item_id)
-                .eq("location_id", purchase.location_id)
-                .limit(1);
-              if (levels && levels.length > 0) {
-                const level = levels[0];
-                const newQty = Math.max(0, Number(level.quantity || 0) - receivedQty);
-                await supabase
-                  .from("inventory_levels")
-                  .update({ quantity: newQty })
-                  .eq("id", level.id);
-              }
-            }
-          }
+        const hasReceived = (items || []).some(it => Number(it.received_quantity || 0) > 0);
+        if (hasReceived) {
+          toast({ title: "Not allowed", description: "Undo receiving before deleting this purchase.", variant: "destructive" });
+          return;
         }
 
         const { error } = await supabase
@@ -899,11 +937,14 @@ export default function Purchases() {
                         {(purchase.status === 'pending' || purchase.status === 'partial') && (
                           <Button variant="outline" size="sm" onClick={() => openReceiveDialog(purchase.id)}>Receive Items</Button>
                         )}
+                        {(purchase.status === 'partial' || purchase.status === 'received') && (
+                          <Button variant="outline" size="sm" onClick={() => undoReceiving(purchase.id)}>Undo Receiving</Button>
+                        )}
                         <Button
                           variant="outline"
                           size="sm"
                           className="text-red-600"
-                          disabled={purchase.status === 'received'}
+                          disabled={purchase.status !== 'pending'}
                           onClick={() => handleDelete(purchase.id)}
                         >
                           Delete

--- a/supabase/migrations/20250815090000_enforce_purchase_receiving_inventory.sql
+++ b/supabase/migrations/20250815090000_enforce_purchase_receiving_inventory.sql
@@ -1,0 +1,129 @@
+-- Enforce delete restrictions and auto-inventory sync for Purchases receiving
+BEGIN;
+
+-- 1) Prevent deleting a purchase that has any received items
+CREATE OR REPLACE FUNCTION public.enforce_no_delete_received_purchase()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM public.purchase_items
+    WHERE purchase_id = OLD.id
+      AND COALESCE(received_quantity, 0) > 0
+  ) THEN
+    RAISE EXCEPTION 'Cannot delete purchase with received items. Undo receiving first.';
+  END IF;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_no_delete_received_purchase ON public.purchases;
+CREATE TRIGGER trg_no_delete_received_purchase
+BEFORE DELETE ON public.purchases
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_no_delete_received_purchase();
+
+-- 2) Prevent deleting a purchase item that has any received quantity
+CREATE OR REPLACE FUNCTION public.enforce_no_delete_received_item()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF COALESCE(OLD.received_quantity, 0) > 0 THEN
+    RAISE EXCEPTION 'Cannot delete a purchase item that has received quantity. Undo receiving first.';
+  END IF;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_no_delete_received_item ON public.purchase_items;
+CREATE TRIGGER trg_no_delete_received_item
+BEFORE DELETE ON public.purchase_items
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_no_delete_received_item();
+
+-- 3) Validate received_quantity within [0, quantity]
+CREATE OR REPLACE FUNCTION public.enforce_received_quantity_bounds()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF COALESCE(NEW.received_quantity, 0) < 0 THEN
+    RAISE EXCEPTION 'received_quantity cannot be negative';
+  END IF;
+  IF COALESCE(NEW.received_quantity, 0) > COALESCE(NEW.quantity, 0) THEN
+    RAISE EXCEPTION 'received_quantity cannot exceed ordered quantity';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_enforce_received_quantity_bounds ON public.purchase_items;
+CREATE TRIGGER trg_enforce_received_quantity_bounds
+BEFORE UPDATE OF received_quantity ON public.purchase_items
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_received_quantity_bounds();
+
+-- 4) Auto-sync inventory levels and purchase status when receiving changes
+CREATE OR REPLACE FUNCTION public.sync_inventory_on_purchase_receive()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_delta NUMERIC;
+  v_location UUID;
+  v_total INT;
+  v_fully INT;
+  v_any INT;
+  v_status TEXT;
+BEGIN
+  v_delta := COALESCE(NEW.received_quantity, 0) - COALESCE(OLD.received_quantity, 0);
+  IF v_delta = 0 THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT location_id INTO v_location FROM public.purchases WHERE id = NEW.purchase_id;
+
+  -- If no location set on the purchase, skip inventory sync (app should set it before receiving)
+  IF v_location IS NOT NULL THEN
+    IF v_delta > 0 THEN
+      INSERT INTO public.inventory_levels (item_id, location_id, quantity)
+      VALUES (NEW.item_id, v_location, v_delta)
+      ON CONFLICT (item_id, location_id)
+      DO UPDATE SET quantity = public.inventory_levels.quantity + EXCLUDED.quantity;
+    ELSE
+      UPDATE public.inventory_levels
+      SET quantity = GREATEST(0, COALESCE(quantity, 0) + v_delta)
+      WHERE item_id = NEW.item_id AND location_id = v_location;
+    END IF;
+  END IF;
+
+  -- Recompute purchase status
+  SELECT COUNT(*) INTO v_total
+  FROM public.purchase_items
+  WHERE purchase_id = NEW.purchase_id;
+
+  SELECT COUNT(*) INTO v_fully
+  FROM public.purchase_items
+  WHERE purchase_id = NEW.purchase_id
+    AND COALESCE(received_quantity, 0) >= COALESCE(quantity, 0);
+
+  SELECT COUNT(*) INTO v_any
+  FROM public.purchase_items
+  WHERE purchase_id = NEW.purchase_id
+    AND COALESCE(received_quantity, 0) > 0;
+
+  IF v_total > 0 AND v_fully = v_total THEN
+    v_status := 'received';
+  ELSIF v_any > 0 THEN
+    v_status := 'partial';
+  ELSE
+    v_status := 'pending';
+  END IF;
+
+  UPDATE public.purchases SET status = v_status, updated_at = NOW() WHERE id = NEW.purchase_id;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_sync_inventory_on_purchase_receive ON public.purchase_items;
+CREATE TRIGGER trg_sync_inventory_on_purchase_receive
+AFTER UPDATE OF received_quantity ON public.purchase_items
+FOR EACH ROW
+EXECUTE FUNCTION public.sync_inventory_on_purchase_receive();
+
+COMMIT;


### PR DESCRIPTION
Add 'Undo Receiving' functionality and restrict purchase deletion to ensure accurate inventory and data integrity.

This PR introduces an "Undo Receiving" action that reverses inventory updates and resets received quantities for a purchase. It also enforces that purchases can only be deleted if they are in a 'pending' state, preventing deletion of partially or fully received purchases without first undoing the receiving process.

---
<a href="https://cursor.com/background-agent?bcId=bc-b002c31a-2bc1-4652-9572-bbd3b2bcd762">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b002c31a-2bc1-4652-9572-bbd3b2bcd762">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

