### PR TITLE
Fix undefined statusFilter in purchases

### DIFF
--- a/src/pages/Purchases.tsx
+++ b/src/pages/Purchases.tsx
@@ -76,6 +76,11 @@ export default function Purchases() {
   const orgTaxRate = useOrganizationTaxRate();
   const [applyTax, setApplyTax] = useState<boolean>(true);
 
+  // Filters
+  const [statusFilter, setStatusFilter] = useState<'all' | 'pending' | 'partial' | 'received' | 'cancelled'>('all');
+  const [vendorFilter, setVendorFilter] = useState<string>('all');
+  const [dateFrom, setDateFrom] = useState<string>('');
+  const [dateTo, setDateTo] = useState<string>('');
 
 
   const [formData, setFormData] = useState({


### PR DESCRIPTION
Add missing state variables for purchase filters to resolve ReferenceError.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf3ad4a7-bf1b-4bad-a60f-c1c50eca90bf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bf3ad4a7-bf1b-4bad-a60f-c1c50eca90bf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

