### PR TITLE
Fix undefined statusfilter in purchases

### DIFF
--- a/src/pages/Purchases.tsx
+++ b/src/pages/Purchases.tsx
@@ -82,6 +82,16 @@ export default function Purchases() {
   const [dateFrom, setDateFrom] = useState<string>('');
   const [dateTo, setDateTo] = useState<string>('');
 
+  // Payments state
+  const [accounts, setAccounts] = useState<AccountOption[]>([]);
+  const [payOpen, setPayOpen] = useState(false);
+  const [payPurchaseId, setPayPurchaseId] = useState<string | null>(null);
+  const [selectedAccountId, setSelectedAccountId] = useState<string>("");
+  const [payAmount, setPayAmount] = useState<string>("");
+  const [payDate, setPayDate] = useState<string>("");
+  const [payReference, setPayReference] = useState<string>("");
+  const [payLoading, setPayLoading] = useState<boolean>(false);
+
 
   const [formData, setFormData] = useState({
     purchase_number: "",


### PR DESCRIPTION
Add missing state hooks for payment-related variables to prevent potential runtime `ReferenceError`s.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ac11474-6239-41bb-8ef3-8722ed63aadb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8ac11474-6239-41bb-8ef3-8722ed63aadb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

