### PR TITLE
Fix payopen reference error in purchases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "tailwindcss": "^3.4.11",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.0.1",
-        "vite": "^5.4.19"
+        "vite": "5.4.19"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/src/pages/Purchases.tsx
+++ b/src/pages/Purchases.tsx
@@ -84,7 +84,7 @@ export default function Purchases() {
 
   // Payments state
   const [accounts, setAccounts] = useState<AccountOption[]>([]);
-  const [payOpen, setPayOpen] = useState(false);
+  const [isPayDialogOpen, setIsPayDialogOpen] = useState(false);
   const [payPurchaseId, setPayPurchaseId] = useState<string | null>(null);
   const [selectedAccountId, setSelectedAccountId] = useState<string>("");
   const [payAmount, setPayAmount] = useState<string>("");
@@ -615,7 +615,7 @@ export default function Purchases() {
     }
     setPayReference("");
     setPayDate(new Date().toISOString().slice(0,10));
-    setPayOpen(true);
+    setIsPayDialogOpen(true);
   };
 
   const submitPay = async (e: React.FormEvent) => {
@@ -644,7 +644,7 @@ export default function Purchases() {
       });
       if (error) throw error;
       toast({ title: "Paid", description: "Purchase payment recorded" });
-      setPayOpen(false);
+      setIsPayDialogOpen(false);
       setPayPurchaseId(null);
       fetchPurchases();
     } catch (err: any) {
@@ -1110,7 +1110,7 @@ export default function Purchases() {
       </Dialog>
 
       {/* Pay Dialog */}
-      <Dialog open={payOpen} onOpenChange={setPayOpen}>
+      <Dialog open={isPayDialogOpen} onOpenChange={setIsPayDialogOpen}>
         <DialogContent className="max-w-md">
           <DialogHeader>
             <DialogTitle className="text-xl">Pay Purchase</DialogTitle>
@@ -1140,7 +1140,7 @@ export default function Purchases() {
               <Input value={payReference} onChange={(e) => setPayReference(e.target.value)} placeholder="Optional" />
             </div>
             <div className="flex justify-end gap-2">
-              <Button type="button" variant="outline" onClick={() => setPayOpen(false)}>Cancel</Button>
+              <Button type="button" variant="outline" onClick={() => setIsPayDialogOpen(false)}>Cancel</Button>
               <Button type="submit" disabled={payLoading}>{payLoading ? 'Paying...' : 'Pay'}</Button>
             </div>
           </form>


### PR DESCRIPTION
Rename `payOpen` state to `isPayDialogOpen` to fix a `ReferenceError` caused by a suspected naming conflict.

---
<a href="https://cursor.com/background-agent?bcId=bc-1300d7d6-6a7f-4493-ae5d-7665df348905">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1300d7d6-6a7f-4493-ae5d-7665df348905">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

