### PR TITLE
Fix staff creation and saving

### DIFF
--- a/src/pages/Staff.tsx
+++ b/src/pages/Staff.tsx
@@ -172,11 +172,20 @@ export default function Staff() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     
+    // Only send columns that exist in current DB schema
+    const payload = {
+      full_name: formData.full_name,
+      email: formData.email || null,
+      phone: formData.phone || null,
+      specialties: formData.specialties || [],
+      is_active: formData.is_active,
+    };
+    
     try {
       if (editingStaff) {
         const { error } = await supabase
           .from("staff")
-          .update(formData)
+          .update(payload)
           .eq("id", editingStaff.id);
 
         if (error) throw error;
@@ -188,7 +197,7 @@ export default function Staff() {
       } else {
         const { error } = await supabase
           .from("staff")
-          .insert([formData]);
+          .insert([payload]);
 
         if (error) throw error;
 


### PR DESCRIPTION
Update staff create/update logic to only send valid columns to fix save errors.

The previous implementation was attempting to insert/update columns (`commission_rate`, `hire_date`, `profile_image`) that do not exist in the current `staff` table schema, causing Supabase to reject the save operation.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ba108fc-b9ff-4054-8f84-34eea1cb91ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6ba108fc-b9ff-4054-8f84-34eea1cb91ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

