### PR TITLE
Add inventory adjustment deletion functionality

### DIFF
--- a/src/pages/InventoryAdjustments.tsx
+++ b/src/pages/InventoryAdjustments.tsx
@@ -309,6 +309,11 @@ export default function InventoryAdjustments() {
 
       if (error) throw error;
       toast.success("Adjustment deleted" + (adj?.status === 'approved' ? " and stock reverted" : ""));
+      // If the deleted adjustment is open in the view modal, close it
+      if (viewingAdjustment?.id === adjustmentId) {
+        setIsViewModalOpen(false);
+        setViewingAdjustment(null);
+      }
       fetchAdjustments();
     } catch (error) {
       console.error("Error deleting adjustment:", error);
@@ -708,15 +713,15 @@ export default function InventoryAdjustments() {
                           >
                             <CheckCircle className="h-4 w-4" />
                           </Button>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => handleDelete(adjustment.id)}
-                          >
-                            <Trash2 className="h-4 w-4" />
-                          </Button>
                         </>
                       )}
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleDelete(adjustment.id)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
                     </div>
                   </TableCell>
                 </TableRow>


### PR DESCRIPTION
Add functionality to delete inventory adjustments, allowing deletion of any adjustment and ensuring UI consistency.

The delete button is now available for all inventory adjustments, regardless of their status. If an approved adjustment is deleted, the associated stock change is reverted via a database trigger, and a toast notification confirms this. Additionally, if the deleted adjustment was open in the view modal, the modal will now automatically close.

---
<a href="https://cursor.com/background-agent?bcId=bc-ff7eb077-49fc-4058-8c5c-0325533ae78a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ff7eb077-49fc-4058-8c5c-0325533ae78a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

