### PR TITLE
Fix missing business locations table

### DIFF
--- a/setup_database.sql
+++ b/setup_database.sql
@@ -187,7 +187,13 @@ BEGIN
     RAISE NOTICE 'All required functions exist and are properly configured';
 END $$;
 
--- 7. Completion message
+-- 7. Reload PostgREST schema to avoid cache issues
+DO $$
+BEGIN
+  PERFORM pg_notify('pgrst', 'reload schema');
+END $$;
+
+-- 8. Completion message
 DO $$
 BEGIN
     RAISE NOTICE 'Database setup completed successfully!';

--- a/supabase/migrations/20250821100000_reload_schema_after_business_locations.sql
+++ b/supabase/migrations/20250821100000_reload_schema_after_business_locations.sql
@@ -1,0 +1,4 @@
+-- Ensure PostgREST reloads schema after creating/modifying business_locations and related objects
+DO $$ BEGIN
+  PERFORM pg_notify('pgrst', 'reload schema');
+END $$;


### PR DESCRIPTION
Add schema reload notifications to resolve 'table not found in schema cache' errors for `business_locations`.

---
<a href="https://cursor.com/background-agent?bcId=bc-0fd2647f-7145-49cd-9902-3d62f63abe04">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0fd2647f-7145-49cd-9902-3d62f63abe04">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

