### PR TITLE
Add sales and purchase price columns to inventory

### DIFF
--- a/src/pages/Inventory.tsx
+++ b/src/pages/Inventory.tsx
@@ -381,8 +381,10 @@ export default function Inventory() {
     quantity: true,
     reorder_point: true,
     status: true,
+    selling_price: false,
+    purchase_price: false,
   } as const;
-  const [visibleColumns, setVisibleColumns] = useState<{ sku: boolean; unit: boolean; quantity: boolean; reorder_point: boolean; status: boolean }>(
+  const [visibleColumns, setVisibleColumns] = useState<{ sku: boolean; unit: boolean; quantity: boolean; reorder_point: boolean; status: boolean; selling_price: boolean; purchase_price: boolean }>(
     () => {
       try {
         const stored = localStorage.getItem('inventory_visible_columns');
@@ -790,6 +792,18 @@ export default function Inventory() {
                     >
                       Status
                     </DropdownMenuCheckboxItem>
+                    <DropdownMenuCheckboxItem
+                      checked={visibleColumns.selling_price}
+                      onCheckedChange={(v) => setVisibleColumns((prev) => ({ ...prev, selling_price: !!v }))}
+                    >
+                      Selling Price
+                    </DropdownMenuCheckboxItem>
+                    <DropdownMenuCheckboxItem
+                      checked={visibleColumns.purchase_price}
+                      onCheckedChange={(v) => setVisibleColumns((prev) => ({ ...prev, purchase_price: !!v }))}
+                    >
+                      Purchase Price
+                    </DropdownMenuCheckboxItem>
                   </DropdownMenuContent>
                 </DropdownMenu>
               </div>
@@ -806,6 +820,12 @@ export default function Inventory() {
                         )}
                         {visibleColumns.unit && (
                           <TableHead className="hidden md:table-cell">Unit</TableHead>
+                        )}
+                        {visibleColumns.selling_price && (
+                          <TableHead className="hidden lg:table-cell">Selling Price</TableHead>
+                        )}
+                        {visibleColumns.purchase_price && (
+                          <TableHead className="hidden lg:table-cell">Purchase Price</TableHead>
                         )}
                         {visibleColumns.quantity && (
                           <TableHead className="text-right">Quantity</TableHead>
@@ -833,6 +853,12 @@ export default function Inventory() {
                             )}
                             {visibleColumns.unit && (
                               <TableCell className="hidden md:table-cell">{item.unit}</TableCell>
+                            )}
+                            {visibleColumns.selling_price && (
+                              <TableCell className="hidden lg:table-cell">{formatMoney(Number(item.selling_price || 0))}</TableCell>
+                            )}
+                            {visibleColumns.purchase_price && (
+                              <TableCell className="hidden lg:table-cell">{formatMoney(Number(item.cost_price || 0))}</TableCell>
                             )}
                             {visibleColumns.quantity && (
                               <TableCell className="text-right">{new Intl.NumberFormat('en-US').format(itemIdToQty.get(item.id) || 0)}</TableCell>


### PR DESCRIPTION
Add selectable Sales Price and Purchase Price columns to the Inventory Listing page.

---
<a href="https://cursor.com/background-agent?bcId=bc-440e1cc4-6d2e-49b2-a1ed-6dd87873c048">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-440e1cc4-6d2e-49b2-a1ed-6dd87873c048">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

