### PR TITLE
Fix missing business locations table

### DIFF
--- a/setup_database.sql
+++ b/setup_database.sql
@@ -4,6 +4,9 @@
 -- 1. Run the complete schema migration
 \i supabase/migrations/20250116000004_complete_database_schema.sql
 
+-- Replace invoices with receipts (ensures receipts exist before adding location_id)
+\i supabase/migrations/20250809000000_replace_invoices_with_receipts.sql
+
 -- Also include business locations and related columns
 \i supabase/migrations/20250812090000_add_business_locations_and_location_filters.sql
 -- Migrate prior storage_locations usage to business_locations

--- a/supabase/migrations/20250812090000_add_business_locations_and_location_filters.sql
+++ b/supabase/migrations/20250812090000_add_business_locations_and_location_filters.sql
@@ -34,7 +34,7 @@ END $$;
 -- 2) Add location_id to key operational tables (idempotent)
 DO $$ BEGIN
   -- receipts
-  IF NOT EXISTS (
+  IF to_regclass('public.receipts') IS NOT NULL AND NOT EXISTS (
     SELECT 1 FROM information_schema.columns 
     WHERE table_schema='public' AND table_name='receipts' AND column_name='location_id'
   ) THEN
@@ -43,7 +43,7 @@ DO $$ BEGIN
   END IF;
 
   -- receipt_items (optional, derive via receipt; add for convenience)
-  IF NOT EXISTS (
+  IF to_regclass('public.receipt_items') IS NOT NULL AND NOT EXISTS (
     SELECT 1 FROM information_schema.columns 
     WHERE table_schema='public' AND table_name='receipt_items' AND column_name='location_id'
   ) THEN
@@ -52,7 +52,7 @@ DO $$ BEGIN
   END IF;
 
   -- receipt_payments
-  IF NOT EXISTS (
+  IF to_regclass('public.receipt_payments') IS NOT NULL AND NOT EXISTS (
     SELECT 1 FROM information_schema.columns 
     WHERE table_schema='public' AND table_name='receipt_payments' AND column_name='location_id'
   ) THEN
@@ -61,7 +61,7 @@ DO $$ BEGIN
   END IF;
 
   -- expenses
-  IF NOT EXISTS (
+  IF to_regclass('public.expenses') IS NOT NULL AND NOT EXISTS (
     SELECT 1 FROM information_schema.columns 
     WHERE table_schema='public' AND table_name='expenses' AND column_name='location_id'
   ) THEN
@@ -70,7 +70,7 @@ DO $$ BEGIN
   END IF;
 
   -- purchases
-  IF NOT EXISTS (
+  IF to_regclass('public.purchases') IS NOT NULL AND NOT EXISTS (
     SELECT 1 FROM information_schema.columns 
     WHERE table_schema='public' AND table_name='purchases' AND column_name='location_id'
   ) THEN
@@ -79,7 +79,7 @@ DO $$ BEGIN
   END IF;
 
   -- appointments (for future location-aware scheduling)
-  IF NOT EXISTS (
+  IF to_regclass('public.appointments') IS NOT NULL AND NOT EXISTS (
     SELECT 1 FROM information_schema.columns 
     WHERE table_schema='public' AND table_name='appointments' AND column_name='location_id'
   ) THEN
@@ -88,7 +88,7 @@ DO $$ BEGIN
   END IF;
 
   -- account_transactions (for P&L and Balance Sheet by location)
-  IF NOT EXISTS (
+  IF to_regclass('public.account_transactions') IS NOT NULL AND NOT EXISTS (
     SELECT 1 FROM information_schema.columns 
     WHERE table_schema='public' AND table_name='account_transactions' AND column_name='location_id'
   ) THEN


### PR DESCRIPTION
Reorder database setup and harden migrations to prevent "relation does not exist" errors during schema application.

The `add_business_locations_and_location_filters.sql` migration attempted to add a `location_id` column to the `public.receipts` table before `public.receipts` was created by `replace_invoices_with_receipts.sql`. This PR ensures the correct migration order in `setup_database.sql` and adds `IF EXISTS` checks to the `ALTER TABLE` statements for robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-95cf1087-1b24-4afb-9764-17ce1e97e074">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-95cf1087-1b24-4afb-9764-17ce1e97e074">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

