### PR TITLE
Fix missing business locations table

### DIFF
--- a/setup_database.sql
+++ b/setup_database.sql
@@ -201,3 +201,6 @@ DO $$
 BEGIN
     RAISE NOTICE 'Database setup completed successfully!';
 END $$;
+
+-- 7. Force PostgREST to reload schema (ensure new tables are visible)
+\i supabase/migrations/20250821100000_reload_schema_after_business_locations.sql


### PR DESCRIPTION
Add PostgREST schema reload to `setup_database.sql` to resolve 'table not found in schema cache' errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-87fb7073-de87-48c5-b2f6-89821817ccbe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-87fb7073-de87-48c5-b2f6-89821817ccbe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

