### PR TITLE
Filter accounts for payments by subtype

### DIFF
--- a/src/pages/Purchases.tsx
+++ b/src/pages/Purchases.tsx
@@ -625,7 +625,12 @@ export default function Purchases() {
             .eq("account_type", "Asset")
             .order("account_code", { ascending: true });
           if (scoped.error) throw scoped.error;
-          data = scoped.data as any[] | null;
+          const allAsset = scoped.data as any[] | null;
+          const filtered = (allAsset || []).filter((a: any) => {
+            const name = String(a.account_name || "");
+            return /cash/i.test(name) || /bank/i.test(name);
+          });
+          data = filtered;
         } else {
           throw error;
         }


### PR DESCRIPTION
Filter purchases payment account fallback to only show Bank or Cash accounts by name.

The existing code in `Purchases.tsx` already filtered accounts by `account_subtype IN ('Cash','Bank')` when the column was present. However, a legacy fallback for older database schemas (where `account_subtype` is missing) previously displayed all Asset accounts. This PR tightens that fallback to ensure only Cash/Bank accounts are shown, even on older schemas, by filtering based on account name.

---
<a href="https://cursor.com/background-agent?bcId=bc-b672154d-7ae4-4339-b92d-c3cc4c43c456">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b672154d-7ae4-4339-b92d-c3cc4c43c456">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

