### PR TITLE
Fix fetchlocations initialization error

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,7 +90,7 @@ importers:
         specifier: ^1.1.0
         version: 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-tooltip':
-        specifier: ^1.1.4
+        specifier: 1.2.7
         version: 1.2.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@supabase/supabase-js':
         specifier: ^2.53.0
@@ -217,7 +217,7 @@ importers:
         specifier: ^8.0.1
         version: 8.39.0(eslint@9.33.0(jiti@1.21.7))(typescript@5.9.2)
       vite:
-        specifier: 5.4.8
+        specifier: ^5.4.8
         version: 5.4.8(@types/node@22.17.1)
 
 packages:

--- a/src/pages/Expenses.tsx
+++ b/src/pages/Expenses.tsx
@@ -107,6 +107,20 @@ export default function Expenses() {
     }
   };
 
+  const fetchLocations = useCallback(async () => {
+    try {
+      const { data, error } = await supabase
+        .from("business_locations")
+        .select("id, name")
+        .order("name");
+      if (error) throw error;
+      setLocations((data || []) as LocationOption[]);
+    } catch (err) {
+      console.warn("Failed to load business locations", err);
+      setLocations([]);
+    }
+  }, []);
+
   useEffect(() => {
     fetchExpenses();
     fetchLocations();
@@ -182,20 +196,6 @@ export default function Expenses() {
     } catch (err) {
       console.warn("Failed to load payment accounts", err);
       setPaymentAccounts([]);
-    }
-  }, []);
-
-  const fetchLocations = useCallback(async () => {
-    try {
-      const { data, error } = await supabase
-        .from("business_locations")
-        .select("id, name")
-        .order("name");
-      if (error) throw error;
-      setLocations((data || []) as LocationOption[]);
-    } catch (err) {
-      console.warn("Failed to load business locations", err);
-      setLocations([]);
     }
   }, []);
 


### PR DESCRIPTION
Move `fetchLocations` hook definition to resolve a `ReferenceError` in `Expenses.tsx`.

The `fetchLocations` function was being called within a `useEffect` hook before its definition, leading to a temporal dead zone error. Moving its definition above the `useEffect` ensures it is initialized before being accessed.

---
<a href="https://cursor.com/background-agent?bcId=bc-59a5b984-3699-4716-8036-6f831324e67c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-59a5b984-3699-4716-8036-6f831324e67c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

