### PR TITLE
Improve edit receipt modal for service items

### DIFF
--- a/src/pages/Expenses.tsx
+++ b/src/pages/Expenses.tsx
@@ -288,18 +288,22 @@ export default function Expenses() {
 
         if (error) throw error;
 
+        // Upsert bank transaction if provided
+        if (paidFromAccountId) {
+          await upsertExpenseBankTransaction(updated.id, amountNumber, paidFromAccountId, expenseData.expense_date, expenseData.vendor_name || 'Expense');
         }
-        toast({
-          title: "Success",
-          description: "Expense updated successfully",
-        });
+        toast({ title: "Success", description: "Expense updated successfully" });
       } else {
-
+        const { data: created, error } = await supabase
+          .from("expenses")
+          .insert([expenseData])
+          .select("*")
+          .single();
+        if (error) throw error;
+        if (paidFromAccountId) {
+          await upsertExpenseBankTransaction(created.id, amountNumber, paidFromAccountId, expenseData.expense_date, expenseData.vendor_name || 'Expense');
         }
-        toast({
-          title: "Success",
-          description: "Expense created successfully",
-        });
+        toast({ title: "Success", description: "Expense created successfully" });
       }
 
       setIsModalOpen(false);

--- a/src/utils/mockDatabase.ts
+++ b/src/utils/mockDatabase.ts
@@ -570,6 +570,10 @@ export async function updateReceiptWithFallback(supabase: any, id: string, updat
     if (typeof updates.status !== 'undefined') allowed.status = updates.status;
     if (typeof updates.notes !== 'undefined') allowed.notes = updates.notes;
     if (typeof updates.receipt_number !== 'undefined') allowed.receipt_number = updates.receipt_number;
+    if (typeof updates.subtotal !== 'undefined') allowed.subtotal = updates.subtotal;
+    if (typeof updates.tax_amount !== 'undefined') allowed.tax_amount = updates.tax_amount;
+    if (typeof updates.discount_amount !== 'undefined') allowed.discount_amount = updates.discount_amount;
+    if (typeof updates.total_amount !== 'undefined') allowed.total_amount = updates.total_amount;
 
     const { error } = await supabase
       .from('receipts')


### PR DESCRIPTION
Adds service items to receipts via job card fallback and expands the Edit Receipt modal with detailed financial fields.

---
<a href="https://cursor.com/background-agent?bcId=bc-2e6108ec-8fbf-41dc-bf08-a51e7e408521">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2e6108ec-8fbf-41dc-bf08-a51e7e408521">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

