### PR TITLE
Remove levels tab from stock transfer

### DIFF
--- a/src/pages/StockTransfers.tsx
+++ b/src/pages/StockTransfers.tsx
@@ -461,7 +461,6 @@ export default function StockTransfers() {
       <Tabs defaultValue="new" className="space-y-6">
         <TabsList>
           <TabsTrigger value="new">New Transfer</TabsTrigger>
-          <TabsTrigger value="levels">Levels</TabsTrigger>
           <TabsTrigger value="history">History</TabsTrigger>
         </TabsList>
 
@@ -535,37 +534,6 @@ export default function StockTransfers() {
           </Card>
         </TabsContent>
 
-        <TabsContent value="levels">
-          {/* Levels Card */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Current Levels</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="overflow-x-auto">
-                <Table className="w-full">
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Location</TableHead>
-                      <TableHead>Item</TableHead>
-                      <TableHead className="text-right">Quantity</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {!loading &&
-                      levels.map((row) => (
-                        <TableRow key={row.id}>
-                          <TableCell>{row.business_locations?.name || row.location_id}</TableCell>
-                          <TableCell>{row.inventory_items?.name || row.item_id}</TableCell>
-                          <TableCell className="text-right">{Number(row.quantity || 0)}</TableCell>
-                        </TableRow>
-                      ))}
-                  </TableBody>
-                </Table>
-              </div>
-            </CardContent>
-          </Card>
-        </TabsContent>
 
         <TabsContent value="history">
           <Card>


### PR DESCRIPTION
Removes the 'Levels' tab from the Stock Transfer Listing Window as requested, and fixes an unrelated syntax issue in `Expenses.tsx`.

The syntax issue in `Expenses.tsx` was an unhandled `handleSubmit` logic that caused a build error after the initial tab removal. It was resolved to ensure a clean build.

---
<a href="https://cursor.com/background-agent?bcId=bc-aae53d23-199b-4622-8991-5408bd8f15c9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aae53d23-199b-4622-8991-5408bd8f15c9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

