### PR TITLE
Fix missing location_id in inventory adjustments

### DIFF
--- a/supabase/migrations/20250826091500_add_location_to_inventory_adjustments.sql
+++ b/supabase/migrations/20250826091500_add_location_to_inventory_adjustments.sql
@@ -1,0 +1,30 @@
+-- Add location_id to inventory_adjustments with FK to business_locations and index (idempotent)
+DO $$ BEGIN
+  -- Add column if missing
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_schema='public' AND table_name='inventory_adjustments' AND column_name='location_id'
+  ) THEN
+    EXECUTE 'ALTER TABLE public.inventory_adjustments ADD COLUMN location_id uuid NULL';
+  END IF;
+
+  -- Add FK constraint if missing
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_schema='public' AND table_name='inventory_adjustments' AND column_name='location_id'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname='inventory_adjustments_location_id_fkey'
+  ) THEN
+    EXECUTE 'ALTER TABLE public.inventory_adjustments 
+             ADD CONSTRAINT inventory_adjustments_location_id_fkey 
+             FOREIGN KEY (location_id) REFERENCES public.business_locations(id) ON DELETE SET NULL';
+  END IF;
+
+  -- Create index if missing
+  EXECUTE 'CREATE INDEX IF NOT EXISTS idx_inventory_adjustments_location_id ON public.inventory_adjustments(location_id)';
+END $$;
+
+-- Reload PostgREST schema cache
+DO $$ BEGIN
+  PERFORM pg_notify('pgrst', 'reload schema');
+END $$;


### PR DESCRIPTION
Add `location_id` column to `inventory_adjustments` table to resolve schema cache errors during adjustment saves.

The application was attempting to save inventory adjustments with a `location_id`, but the `inventory_adjustments` table in the database (or PostgREST's schema cache) was missing this column, leading to a "column not found" error. This PR adds the necessary column and ensures the schema cache is refreshed.

---
<a href="https://cursor.com/background-agent?bcId=bc-bae1885b-1a77-4988-8938-832eb7fc8b87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bae1885b-1a77-4988-8938-832eb7fc8b87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

