### PR TITLE
Enable organization address editing without prefill

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -33,7 +33,7 @@ export default function Settings() {
   // Company Settings State
   const [companyData, setCompanyData] = useState({
     name: "SalonSync Demo",
-    address: "123 Beauty Street",
+    address: "",
     city: "New York",
         country: "US",
 phone: "+1 (555) 123-4567",
@@ -232,7 +232,7 @@ phone: "+1 (555) 123-4567",
       setCompanyData(prev => ({
         ...prev,
         name: organization.name || prev.name,
-        address: s.address || prev.address,
+        address: s.address || "",
         city: s.city || prev.city,
         country: s.country || prev.country,
         phone: s.phone || prev.phone,


### PR DESCRIPTION
Allow editing of the Organization Address by preventing it from prefilling with a demo value.

---
<a href="https://cursor.com/background-agent?bcId=bc-015771ac-dfc6-4384-9514-fc6cd7b175f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-015771ac-dfc6-4384-9514-fc6cd7b175f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

