### PR TITLE
Investigate transfer save error

### DIFF
--- a/src/utils/ledger.ts
+++ b/src/utils/ledger.ts
@@ -151,7 +151,6 @@ export async function postDoubleEntry(params: LedgerPostParams): Promise<boolean
           credit_amount: 0,
           reference_type: referenceType || null,
           reference_id: referenceId || null,
-          organization_id: organizationId,
           location_id: locationId || null,
         },
         {
@@ -162,7 +161,6 @@ export async function postDoubleEntry(params: LedgerPostParams): Promise<boolean
           credit_amount: amount,
           reference_type: referenceType || null,
           reference_id: referenceId || null,
-          organization_id: organizationId,
           location_id: locationId || null,
         },
       ]);


### PR DESCRIPTION
Remove `organization_id` from `account_transactions` inserts to fix "Transfer Failed" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-d458d22d-1c00-4e54-9b7d-3c4e158c8e18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d458d22d-1c00-4e54-9b7d-3c4e158c8e18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

