### PR TITLE
Fix select item value prop

### DIFF
--- a/src/pages/Expenses.tsx
+++ b/src/pages/Expenses.tsx
@@ -538,13 +538,13 @@ export default function Expenses() {
                   <div className="grid grid-cols-2 gap-4">
                     <div className="space-y-2">
                       <Label htmlFor="category">Account</Label>
-                      <Select value={formData.category} onValueChange={(value) => setFormData({ ...formData, category: value })}>
+                      <Select value={formData.category} onValueChange={(value) => { const acc = expenseAccounts.find(a => a.account_name === value || a.id === value); setFormData({ ...formData, category: acc?.account_name || '' }); }}>
                         <SelectTrigger>
                           <SelectValue placeholder="Select expense account" />
                         </SelectTrigger>
                         <SelectContent>
                           {expenseAccounts.map(acc => (
-                            <SelectItem key={acc.id} value={acc.account_name}>{acc.account_code} - {acc.account_name}</SelectItem>
+                            <SelectItem key={acc.id} value={acc.account_name || acc.id}>{acc.account_code} - {acc.account_name || 'Unnamed Account'}</SelectItem>
                           ))}
                         </SelectContent>
                       </Select>

--- a/src/pages/Purchases.tsx
+++ b/src/pages/Purchases.tsx
@@ -777,14 +777,14 @@ export default function Purchases() {
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="vendor_name">Vendor</Label>
-                  <Select value={formData.vendor_name} onValueChange={(value) => setFormData({ ...formData, vendor_name: value })}>
+                  <Select value={formData.vendor_name} onValueChange={(value) => { const s = suppliers.find(x => x.name === value || x.id === value); setFormData({ ...formData, vendor_name: s?.name || '' }); }}>
                     <SelectTrigger>
                       <SelectValue placeholder="Select vendor" />
                     </SelectTrigger>
                     <SelectContent>
                       {/* Populated from suppliers table */}
                       {suppliers.map((s) => (
-                        <SelectItem key={s.id} value={s.name}>{s.name}</SelectItem>
+                        <SelectItem key={s.id} value={s.name || s.id}>{s.name || 'Unnamed Supplier'}</SelectItem>
                       ))}
                     </SelectContent>
                   </Select>
@@ -1054,14 +1054,14 @@ export default function Purchases() {
         </div>
         <div>
           <Label className="text-xs text-muted-foreground">Vendor</Label>
-          <Select value={vendorFilter} onValueChange={setVendorFilter}>
+          <Select value={vendorFilter} onValueChange={(value) => { const s = suppliers.find(x => x.name === value || x.id === value); setVendorFilter(s?.name || value); }} >
             <SelectTrigger>
               <SelectValue placeholder="All vendors" />
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="all">All</SelectItem>
               {suppliers.map((s) => (
-                <SelectItem key={s.id} value={s.name}>{s.name}</SelectItem>
+                <SelectItem key={s.id} value={s.name || s.id}>{s.name || 'Unnamed Supplier'}</SelectItem>
               ))}
             </SelectContent>
           </Select>


### PR DESCRIPTION
Ensures Radix `Select.Item` values are never empty strings to resolve runtime errors.

The Radix UI `Select` component throws an error if any `Select.Item` has an empty string as its `value` prop. This PR updates `SelectItem` components in `Expenses.tsx` and `Purchases.tsx` to use a stable ID as a fallback value when dynamic names (like `account_name` or `supplier.name`) are empty. `onValueChange` handlers are also adjusted to correctly map the selected item back to its original name for form state persistence.

---
<a href="https://cursor.com/background-agent?bcId=bc-a1b8294f-b565-4b72-9f4c-84b4c0dcb01a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a1b8294f-b565-4b72-9f4c-84b4c0dcb01a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

