### PR TITLE
Fix missing location_id column in schema cache

### DIFF
--- a/src/pages/ServiceForm.tsx
+++ b/src/pages/ServiceForm.tsx
@@ -273,7 +273,9 @@ export default function ServiceForm() {
         if (updError) {
           const code = (updError as any)?.code;
           const message = (updError as any)?.message || String(updError);
-          const isMissingLocationId = code === '42703' || /column\s+("?[\w\.]*location_id"?)\s+does not exist/i.test(message);
+          const isMissingLocationId = code === '42703'
+            || /column\s+("?[\w\.]*location_id"?)\s+does not exist/i.test(message)
+            || (/schema cache/i.test(message) && /location_id/i.test(message) && /services/i.test(message));
           if (isMissingLocationId) {
             const { error: retryError } = await supabase
               .from("services")
@@ -321,7 +323,9 @@ export default function ServiceForm() {
           const code = (error as any)?.code;
           const message = (error as any)?.message || String(error);
           const isMissingOrgId = code === '42703' || /column\s+("?[\w\.]*organization_id"?)\s+does not exist/i.test(message);
-          const isMissingLocationId = code === '42703' || /column\s+("?[\w\.]*location_id"?)\s+does not exist/i.test(message);
+          const isMissingLocationId = code === '42703'
+            || /column\s+("?[\w\.]*location_id"?)\s+does not exist/i.test(message)
+            || (/schema cache/i.test(message) && /location_id/i.test(message) && /services/i.test(message));
           if (isMissingOrgId || isMissingLocationId) {
             const { data: retryData, error: retryError } = await supabase
               .from("services")

--- a/supabase/migrations/20250830094500_add_location_to_services.sql
+++ b/supabase/migrations/20250830094500_add_location_to_services.sql
@@ -1,0 +1,78 @@
+-- Add organization_id and location_id to services with FKs and indexes (idempotent)
+DO $$ BEGIN
+  -- Add organization_id if missing
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_schema='public' AND table_name='services' AND column_name='organization_id'
+  ) THEN
+    EXECUTE 'ALTER TABLE public.services ADD COLUMN organization_id uuid NULL';
+  END IF;
+
+  -- Add location_id if missing
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_schema='public' AND table_name='services' AND column_name='location_id'
+  ) THEN
+    EXECUTE 'ALTER TABLE public.services ADD COLUMN location_id uuid NULL';
+  END IF;
+
+  -- Add FK for organization_id if column exists and FK not present
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_schema='public' AND table_name='services' AND column_name='organization_id'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname='services_organization_id_fkey'
+  ) THEN
+    EXECUTE 'ALTER TABLE public.services 
+             ADD CONSTRAINT services_organization_id_fkey 
+             FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE SET NULL';
+  END IF;
+
+  -- Add FK for location_id if column exists and FK not present
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_schema='public' AND table_name='services' AND column_name='location_id'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname='services_location_id_fkey'
+  ) THEN
+    EXECUTE 'ALTER TABLE public.services 
+             ADD CONSTRAINT services_location_id_fkey 
+             FOREIGN KEY (location_id) REFERENCES public.business_locations(id) ON DELETE SET NULL';
+  END IF;
+
+  -- Indexes
+  EXECUTE 'CREATE INDEX IF NOT EXISTS idx_services_organization_id ON public.services(organization_id)';
+  EXECUTE 'CREATE INDEX IF NOT EXISTS idx_services_location_id ON public.services(location_id)';
+END $$;
+
+-- Best-effort backfill of location_id using default business location when possible
+DO $$ DECLARE
+  rec RECORD;
+  v_default_location UUID;
+BEGIN
+  FOR rec IN SELECT id, organization_id FROM public.services WHERE location_id IS NULL LOOP
+    IF rec.organization_id IS NOT NULL THEN
+      SELECT bl.id INTO v_default_location
+      FROM public.business_locations bl
+      WHERE bl.organization_id = rec.organization_id AND bl.is_default = true
+      LIMIT 1;
+
+      IF v_default_location IS NULL THEN
+        SELECT bl.id INTO v_default_location
+        FROM public.business_locations bl
+        WHERE bl.organization_id = rec.organization_id
+        ORDER BY bl.created_at NULLS LAST, bl.id
+        LIMIT 1;
+      END IF;
+
+      IF v_default_location IS NOT NULL THEN
+        UPDATE public.services SET location_id = v_default_location WHERE id = rec.id;
+      END IF;
+    END IF;
+  END LOOP;
+END $$;
+
+-- Reload PostgREST schema cache so new columns are visible immediately
+DO $$ BEGIN
+  PERFORM pg_notify('pgrst', 'reload schema');
+END $$;


### PR DESCRIPTION
Add `location_id` and `organization_id` to `services` table and handle schema cache errors in UI.

This PR introduces an idempotent migration to add `location_id` and `organization_id` columns, along with foreign keys and indexes, to the `public.services` table. It also updates `ServiceForm.tsx` to specifically handle "schema cache" errors related to `location_id` on `services` by retrying the save operation without that field, ensuring robustness against stale schema caches.

---
<a href="https://cursor.com/background-agent?bcId=bc-10a5293e-731f-476f-9415-b6f276d75f32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-10a5293e-731f-476f-9415-b6f276d75f32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

