### PR TITLE
Fix useorganization hook not defined

### DIFF
--- a/src/pages/Staff.tsx
+++ b/src/pages/Staff.tsx
@@ -48,7 +48,7 @@ import { CreateButtonGate, FeatureGate, UsageBadge } from "@/components/features
 import { format } from "date-fns";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { useNavigate } from "react-router-dom";
-import { useOrganizationCurrency } from "@/lib/saas/hooks";
+import { useOrganizationCurrency, useOrganization } from "@/lib/saas/hooks";
 
 interface Staff {
   id: string;


### PR DESCRIPTION
Fixes `ReferenceError: useOrganization` by adding the missing import to `src/pages/Staff.tsx`.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc45c2f0-5f58-4b08-a911-02e08fc3cabc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dc45c2f0-5f58-4b08-a911-02e08fc3cabc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

