### PR TITLE
Fix salesHistory undefined reference

### DIFF
--- a/src/pages/ServiceView.tsx
+++ b/src/pages/ServiceView.tsx
@@ -42,6 +42,21 @@ interface ServiceKit {
   };
 }
 
+interface SalesHistoryRow {
+  id: string;
+  receipt_id: string;
+  description: string;
+  quantity: number;
+  unit_price: number;
+  total_price: number;
+  staff_id: string | null;
+  created_at: string;
+  receipt_number?: string | null;
+  receipt_created_at?: string | null;
+  customer_id?: string | null;
+  staff_name?: string | null;
+}
+
 export default function ServiceView() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -49,6 +64,8 @@ export default function ServiceView() {
   const [service, setService] = useState<Service | null>(null);
   const [serviceKits, setServiceKits] = useState<ServiceKit[]>([]);
   const [loading, setLoading] = useState(true);
+  const [salesHistory, setSalesHistory] = useState<SalesHistoryRow[]>([]);
+  const [salesLoading, setSalesLoading] = useState<boolean>(false);
 
 
   const fetchServiceData = useCallback(async () => {


### PR DESCRIPTION
Add missing state and type definitions for `salesHistory` and `salesLoading` to resolve a `ReferenceError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-82b3e9aa-ca32-4c6b-adc3-0a1e4c588fab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-82b3e9aa-ca32-4c6b-adc3-0a1e4c588fab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

