### PR TITLE
Fix useSaas context error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -198,12 +198,10 @@ const AppRoutes = () => {
 function App() {
   return (
     <ErrorBoundary>
-      <SaasProvider>
-        <Router>
-          <AppRoutes />
-          <Toaster />
-        </Router>
-      </SaasProvider>
+      <Router>
+        <AppRoutes />
+        <Toaster />
+      </Router>
     </ErrorBoundary>
   );
 }

--- a/src/components/features/UsageDashboard.tsx
+++ b/src/components/features/UsageDashboard.tsx
@@ -5,7 +5,7 @@ import { Progress } from '@/components/ui/progress';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { useFeatureGating } from '@/hooks/useFeatureGating';
-import { useSaas } from '@/lib/saas/context';
+import { useSaas } from '@/lib/saas';
 import { FEATURE_LABELS, FEATURE_CATEGORIES } from '@/lib/features';
 import { 
   Users, 

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -44,7 +44,7 @@ import {
 } from "@/components/ui/sidebar";
 import { Badge } from "@/components/ui/badge";
 import { useFeatureGating } from "@/hooks/useFeatureGating";
-import { useSaas } from "@/lib/saas/context";
+import { useSaas } from "@/lib/saas";
 
 interface MenuSubItem {
   title: string;

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -2,7 +2,7 @@ import { Outlet } from "react-router-dom";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { AppSidebar } from "./AppSidebar";
 import { AppTopbar } from "./Topbar";
-import { useSaas } from "@/lib/saas/context";
+import { useSaas } from "@/lib/saas";
 import { supabase } from "@/integrations/supabase/client";
 import { useNavigate } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";

--- a/src/components/layout/SuperAdminLayout.tsx
+++ b/src/components/layout/SuperAdminLayout.tsx
@@ -2,7 +2,7 @@ import { Outlet } from "react-router-dom";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { SuperAdminSidebar } from "./SuperAdminSidebar";
 import { SuperAdminTopbar } from "./Topbar";
-import { useSaas } from "@/lib/saas/context";
+import { useSaas } from "@/lib/saas";
 import { supabase } from "@/integrations/supabase/client";
 import { useNavigate } from "react-router-dom";
 

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -5,7 +5,7 @@ import { Input } from "@/components/ui/input";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Bell, Building2, ChevronDown, CreditCard, Crown, LogOut, Search, Settings, Shield, User } from "lucide-react";
-import { useSaas } from "@/lib/saas/context";
+import { useSaas } from "@/lib/saas";
 import { supabase } from "@/integrations/supabase/client";
 import { useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,10 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { SaasProvider } from '@/lib/saas'
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <SaasProvider>
+    <App />
+  </SaasProvider>
+);

--- a/src/pages/BillingHistory.tsx
+++ b/src/pages/BillingHistory.tsx
@@ -3,7 +3,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Badge } from "@/components/ui/badge";
 import { useOrganizationCurrency } from "@/lib/saas/hooks";
 import { supabase } from "@/integrations/supabase/client";
-import { useSaas } from "@/lib/saas/context";
+import { useSaas } from "@/lib/saas";
 import { useEffect, useState } from "react";
 
 export default function BillingHistory() {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -43,7 +43,7 @@ import {
   CreditCard
 } from "lucide-react";
 import { format, subDays, startOfDay, endOfDay } from "date-fns";
-import { useSaas } from "@/lib/saas/context";
+import { useSaas } from "@/lib/saas";
 import { useOrganizationCurrency } from "@/lib/saas/hooks";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -25,7 +25,7 @@ import {
   Package,
   DollarSign,
 } from 'lucide-react';
-import { useSaas } from '@/lib/saas/context';
+import { useSaas } from '@/lib/saas';
 
 const Help = () => {
   const { organization } = useSaas();

--- a/src/pages/PaymentMethod.tsx
+++ b/src/pages/PaymentMethod.tsx
@@ -2,7 +2,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { supabase } from "@/integrations/supabase/client";
-import { useSaas } from "@/lib/saas/context";
+import { useSaas } from "@/lib/saas";
 import { useEffect, useState } from "react";
 
 export default function PaymentMethod() {

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -24,7 +24,7 @@ import {
   X,
   Check,
 } from 'lucide-react';
-import { useSaas } from '@/lib/saas/context';
+import { useSaas } from '@/lib/saas';
 import { toast } from 'sonner';
 import { supabase } from '@/integrations/supabase/client';
 

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -23,7 +23,7 @@ import {
   Target,
   Package,
 } from 'lucide-react';
-import { useSaas } from '@/lib/saas/context';
+import { useSaas } from '@/lib/saas';
 import { supabase } from '@/integrations/supabase/client';
 import { useSearchParams } from 'react-router-dom';
 import { mockDb } from '@/utils/mockDatabase';

--- a/src/pages/UpgradePlan.tsx
+++ b/src/pages/UpgradePlan.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { PLAN_FEATURES } from "@/lib/features";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
-import { useSaas } from "@/lib/saas/context";
+import { useSaas } from "@/lib/saas";
 import { useEffect, useState } from "react";
 import { SubscriptionService } from "@/lib/saas/services";
 import { useOrganizationCurrency } from "@/lib/saas/hooks";

--- a/src/pages/admin/AdminSubscriptionPlans.tsx
+++ b/src/pages/admin/AdminSubscriptionPlans.tsx
@@ -14,7 +14,7 @@ import { format } from "date-fns";
 import { toast } from "sonner";
 import SuperAdminLayout from "@/components/layout/SuperAdminLayout";
 import { FEATURE_CATEGORIES, FEATURE_LABELS } from "@/lib/features";
-import { useSaas } from "@/lib/saas/context";
+import { useSaas } from "@/lib/saas";
 import { SuperAdminService } from "@/lib/saas/services";
 import { useOrganizationCurrency } from "@/lib/saas/hooks";
 


### PR DESCRIPTION
Fixes "useSaas must be used within a SaasProvider" error by moving `SaasProvider` to `main.tsx` and unifying `useSaas` imports.

The error was caused by `useSaas` being imported from two different module paths (`@/lib/saas` and `@/lib/saas/context`), which can create multiple context instances, especially in development with HMR. Additionally, the `SaasProvider` was mounted too low in the component tree (`App.tsx`), leading to components attempting to use the hook before the context was available. Moving the provider to `main.tsx` ensures it wraps the entire application, and unifying imports prevents context duplication.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f12fd0b-ca49-498a-b544-4e1290128509">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0f12fd0b-ca49-498a-b544-4e1290128509">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

