### PR TITLE
Check for missing account transactions table

### DIFF
--- a/setup_database.sql
+++ b/setup_database.sql
@@ -12,6 +12,9 @@
 -- Migrate prior storage_locations usage to business_locations
 \i supabase/migrations/20250820093000_migrate_storage_locations_to_business_locations.sql
 
+-- Ensure ledger table exists
+\i supabase/migrations/20250831090000_create_account_transactions.sql
+
 -- 2. Ensure all required functions exist
 -- Create organization creation function if it doesn't exist
 CREATE OR REPLACE FUNCTION create_organization_with_user(


### PR DESCRIPTION
Include `create_account_transactions` migration in `setup_database.sql` to ensure the table exists during setup.

The error "Could not find the table 'public.account_transactions' in the schema cache" indicated that the `account_transactions` table was not present or the PostgREST schema cache was stale. By including its creation migration in `setup_database.sql`, we ensure it's always created when setting up the database, preventing this issue for new environments or fresh setups.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8d74f99-b38c-4217-83e2-b936cde2b89d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d8d74f99-b38c-4217-83e2-b936cde2b89d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

