### PR TITLE
Fix missing organization_users invited_by column

### DIFF
--- a/setup_database.sql
+++ b/setup_database.sql
@@ -11,6 +11,8 @@
 \i supabase/migrations/20250812090000_add_business_locations_and_location_filters.sql
 -- Migrate prior storage_locations usage to business_locations
 \i supabase/migrations/20250820093000_migrate_storage_locations_to_business_locations.sql
+-- Ensure organization_users has invitation fields
+\i supabase/migrations/20250901093000_add_org_users_invitation_fields.sql
 
 -- 2. Ensure all required functions exist
 -- Create organization creation function if it doesn't exist

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -803,6 +803,10 @@ export type Database = {
           role: string
           updated_at: string | null
           user_id: string
+          invited_by: string | null
+          invited_at: string | null
+          joined_at: string | null
+          metadata: Json | null
         }
         Insert: {
           created_at?: string | null
@@ -812,6 +816,10 @@ export type Database = {
           role?: string
           updated_at?: string | null
           user_id: string
+          invited_by?: string | null
+          invited_at?: string | null
+          joined_at?: string | null
+          metadata?: Json | null
         }
         Update: {
           created_at?: string | null
@@ -821,6 +829,10 @@ export type Database = {
           role?: string
           updated_at?: string | null
           user_id?: string
+          invited_by?: string | null
+          invited_at?: string | null
+          joined_at?: string | null
+          metadata?: Json | null
         }
         Relationships: [
           {

--- a/src/lib/saas/services.ts
+++ b/src/lib/saas/services.ts
@@ -34,7 +34,7 @@ export class OrganizationService {
 
         const { data: memberships, error: membershipsError } = await supabase
           .from('organization_users')
-          .select('id, organization_id, user_id, role, is_active, invited_by, invited_at, joined_at, metadata, created_at, updated_at')
+          .select('id, organization_id, user_id, role, is_active, created_at, updated_at')
           .eq('user_id', userId)
           .eq('is_active', true)
 

--- a/supabase/migrations/20250901093000_add_org_users_invitation_fields.sql
+++ b/supabase/migrations/20250901093000_add_org_users_invitation_fields.sql
@@ -1,0 +1,56 @@
+-- Add invitation-related fields to organization_users if missing
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables 
+    WHERE table_schema = 'public' AND table_name = 'organization_users'
+  ) THEN
+    -- invited_by (nullable, FK to auth.users.id)
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns 
+      WHERE table_schema = 'public' AND table_name = 'organization_users' AND column_name = 'invited_by'
+    ) THEN
+      EXECUTE 'ALTER TABLE public.organization_users ADD COLUMN invited_by uuid NULL';
+    END IF;
+
+    -- invited_at (nullable timestamp)
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns 
+      WHERE table_schema = 'public' AND table_name = 'organization_users' AND column_name = 'invited_at'
+    ) THEN
+      EXECUTE 'ALTER TABLE public.organization_users ADD COLUMN invited_at timestamptz NULL';
+    END IF;
+
+    -- joined_at (nullable timestamp)
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns 
+      WHERE table_schema = 'public' AND table_name = 'organization_users' AND column_name = 'joined_at'
+    ) THEN
+      EXECUTE 'ALTER TABLE public.organization_users ADD COLUMN joined_at timestamptz NULL';
+    END IF;
+
+    -- metadata (nullable jsonb with default {})
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns 
+      WHERE table_schema = 'public' AND table_name = 'organization_users' AND column_name = 'metadata'
+    ) THEN
+      EXECUTE 'ALTER TABLE public.organization_users ADD COLUMN metadata jsonb NULL DEFAULT ''{}''::jsonb';
+    END IF;
+  END IF;
+END $$;
+
+-- Add foreign key for invited_by if column and users table exist
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_schema = 'public' AND table_name = 'organization_users' AND column_name = 'invited_by'
+  ) AND EXISTS (
+    SELECT 1 FROM information_schema.tables 
+    WHERE table_schema = 'auth' AND table_name = 'users'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'organization_users_invited_by_fkey'
+  ) THEN
+    EXECUTE 'ALTER TABLE public.organization_users ADD CONSTRAINT organization_users_invited_by_fkey FOREIGN KEY (invited_by) REFERENCES auth.users(id) ON DELETE SET NULL';
+  END IF;
+END $$;


### PR DESCRIPTION
Add missing invitation-related columns to `organization_users` table and update types to fix organization loading errors.

The application was failing to load organizations because the `organization_users` query in `src/lib/saas/services.ts` was attempting to select columns (`invited_by`, `invited_at`, `joined_at`, `metadata`) that did not exist in the database schema. This PR adds these missing columns via a new migration, updates the generated Supabase types, and temporarily adjusts the query to prevent immediate failures until the migration is applied.

---
<a href="https://cursor.com/background-agent?bcId=bc-85729778-4347-407e-a37e-16e0c9ab0008">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-85729778-4347-407e-a37e-16e0c9ab0008">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

