### PR TITLE
Fix dashboard date input error

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -42,7 +42,7 @@ import {
   MessageSquare,
   CreditCard
 } from "lucide-react";
-import { format, subDays, startOfDay, endOfDay } from "date-fns";
+import { format as formatDate, subDays, startOfDay, endOfDay } from "date-fns";
 import { useSaas } from "@/lib/saas/context";
 import { useOrganizationCurrency } from "@/lib/saas/hooks";
 import { useNavigate } from "react-router-dom";
@@ -110,8 +110,8 @@ const Dashboard = () => {
         setLoading(true);
         const today = new Date();
         const yesterday = subDays(today, 1);
-        const todayStr = format(today, 'yyyy-MM-dd');
-        const yesterdayStr = format(yesterday, 'yyyy-MM-dd');
+        const todayStr = formatDate(today, 'yyyy-MM-dd');
+        const yesterdayStr = formatDate(yesterday, 'yyyy-MM-dd');
 
         const appointmentsQuery = supabase
           .from('appointments')


### PR DESCRIPTION
Alias `date-fns` `format` to `formatDate` in `Dashboard.tsx` to fix a name shadowing bug causing invalid date strings.

---
<a href="https://cursor.com/background-agent?bcId=bc-04e6da44-07a4-4a1b-adc0-9a2e54b5cfe5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-04e6da44-07a4-4a1b-adc0-9a2e54b5cfe5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

