### PR TITLE
Fix useSaas hook definition

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -198,10 +198,12 @@ const AppRoutes = () => {
 function App() {
   return (
     <ErrorBoundary>
-      <Router>
-        <AppRoutes />
-        <Toaster />
-      </Router>
+      <SaasProvider>
+        <Router>
+          <AppRoutes />
+          <Toaster />
+        </Router>
+      </SaasProvider>
     </ErrorBoundary>
   );
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -45,6 +45,8 @@ import {
 import { useOrganizationCurrency } from "@/lib/saas/hooks";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
+import { useSaas } from "@/lib/saas";
+import { subDays, startOfDay, endOfDay, format as formatDate } from "date-fns";
 
 // Utility helpers for safe percentage and averages
 const safePercent = (current: number, previous: number) => {


### PR DESCRIPTION
Fix `ReferenceError: useSaas is not defined` by importing `useSaas` and wrapping the app with `SaasProvider`, and add missing `date-fns` imports.

---
<a href="https://cursor.com/background-agent?bcId=bc-6c4712ea-2626-46a2-bcaf-b935b341396f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6c4712ea-2626-46a2-bcaf-b935b341396f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

