### PR TITLE
Fix inventory adjustment location foreign key

### DIFF
--- a/supabase/migrations/20250831123000_fix_invalid_adjustment_locations.sql
+++ b/supabase/migrations/20250831123000_fix_invalid_adjustment_locations.sql
@@ -1,0 +1,33 @@
+-- Fix invalid location references on inventory_adjustments to prevent FK violations during approval
+DO $$
+DECLARE
+  v_default_location uuid;
+BEGIN
+  -- Choose a default active location if available (prefer is_default=true)
+  SELECT bl.id
+  INTO v_default_location
+  FROM public.business_locations bl
+  WHERE COALESCE(bl.is_active, true) = true
+  ORDER BY COALESCE(bl.is_default, false) DESC, bl.created_at NULLS LAST, bl.id
+  LIMIT 1;
+
+  -- Set invalid or missing location_id to default location if present; otherwise NULL
+  UPDATE public.inventory_adjustments ia
+  SET location_id = COALESCE(v_default_location, NULL)
+  WHERE ia.location_id IS NULL
+     OR ia.location_id NOT IN (SELECT id FROM public.business_locations);
+END $$;
+
+-- Optional: verify constraint exists (no-op if already present)
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_schema='public' AND table_name='inventory_adjustments' AND column_name='location_id'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname='inventory_adjustments_location_id_fkey'
+  ) THEN
+    EXECUTE 'ALTER TABLE public.inventory_adjustments 
+             ADD CONSTRAINT inventory_adjustments_location_id_fkey 
+             FOREIGN KEY (location_id) REFERENCES public.business_locations(id) ON DELETE SET NULL';
+  END IF;
+END $$;


### PR DESCRIPTION
Add location validation to inventory adjustments and clean up invalid location IDs to prevent foreign key violations.

The system was failing to approve adjustments due to a foreign key constraint violation on `inventory_levels`, caused by `inventory_adjustments` referencing non-existent `location_id`s. This PR adds checks to prevent new invalid adjustments and a migration to fix existing bad data.

---
<a href="https://cursor.com/background-agent?bcId=bc-98a838f8-fd1e-4246-b7b3-140d12a0f381">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-98a838f8-fd1e-4246-b7b3-140d12a0f381">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

