### PR TITLE
Add transaction drill-down from account list

### DIFF
--- a/src/pages/AccountView.tsx
+++ b/src/pages/AccountView.tsx
@@ -102,6 +102,30 @@ export default function AccountView() {
     });
   }, [filteredTxns, account?.normal_balance]);
 
+  const navigateToReference = (row: TransactionRow) => {
+    const refType = String(row.reference_type || "").toLowerCase();
+    const refId = row.reference_id;
+    if (!refId) return;
+    if (refType === "receipt_payment") {
+      navigate(`/receipts/${refId}`);
+      return;
+    }
+    if (refType === "purchase_payment") {
+      navigate(`/purchases/${refId}`);
+      return;
+    }
+    if (refType === "expense_payment") {
+      navigate(`/expenses/${refId}/edit`);
+      return;
+    }
+    if (refType === "account_transfer") {
+      navigate(`/banking`);
+      return;
+    }
+    // Fallback
+    navigate(`/banking`);
+  };
+
   const onDelete = async () => {
     if (!id) return;
     try {
@@ -226,7 +250,12 @@ export default function AccountView() {
               </TableHeader>
               <TableBody>
                 {rowsWithRunning.map((r) => (
-                  <TableRow key={r.id}>
+                  <TableRow
+                    key={r.id}
+                    onClick={() => r.reference_id && navigateToReference(r)}
+                    className={r.reference_id ? "cursor-pointer hover:bg-slate-50" : ""}
+                    title={r.reference_id ? `Open ${(r.reference_type || '').toString()} ${r.reference_id || ''}` : undefined}
+                  >
                     <TableCell>{new Date(r.transaction_date).toLocaleDateString()}</TableCell>
                     <TableCell className="max-w-[380px] truncate" title={r.description || ''}>{r.description || "—"}</TableCell>
                     <TableCell className="text-right">{Number(r.debit_amount || 0).toFixed(2)}</TableCell>


### PR DESCRIPTION
Add drill-down navigation from account transaction rows to their detail pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-1427750b-fffe-4434-a81f-01dc432d150a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1427750b-fffe-4434-a81f-01dc432d150a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

