### PR TITLE
Fix missing commission rate column

### DIFF
--- a/setup_database.sql
+++ b/setup_database.sql
@@ -22,6 +22,9 @@
 -- Goods received RPCs and RLS policies
 \i supabase/migrations/20250908093000_goods_received_rpcs_and_policies.sql
 
+-- Ensure staff has commission_rate column
+\i supabase/migrations/20250910094500_add_commission_rate_to_staff.sql
+
 -- 2. Ensure all required functions exist
 -- Create organization creation function if it doesn't exist
 CREATE OR REPLACE FUNCTION create_organization_with_user(

--- a/supabase/migrations/20250910094500_add_commission_rate_to_staff.sql
+++ b/supabase/migrations/20250910094500_add_commission_rate_to_staff.sql
@@ -1,0 +1,30 @@
+-- Add commission_rate to staff if missing (idempotent)
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_schema = 'public' 
+      AND table_name = 'staff' 
+      AND column_name = 'commission_rate'
+  ) THEN
+    EXECUTE 'ALTER TABLE public.staff ADD COLUMN commission_rate numeric(5,2) NULL';
+  END IF;
+END $$;
+
+-- Ensure a sane 0-100 bounds check exists (idempotent)
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint 
+    WHERE conname = 'staff_commission_rate_bounds_chk'
+  ) THEN
+    EXECUTE 'ALTER TABLE public.staff
+             ADD CONSTRAINT staff_commission_rate_bounds_chk
+             CHECK (commission_rate IS NULL OR (commission_rate >= 0 AND commission_rate <= 100))';
+  END IF;
+END $$;
+
+-- Optionally backfill: leave NULLs as-is; UI handles defaults
+
+-- Reload PostgREST schema so the new column is available immediately
+DO $$ BEGIN
+  PERFORM pg_notify('pgrst', 'reload schema');
+END $$;


### PR DESCRIPTION
Add `commission_rate` column to the `staff` table to resolve a "column does not exist" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-c36beba5-643d-4e30-acc8-38900c0dcec3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c36beba5-643d-4e30-acc8-38900c0dcec3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

