### PR TITLE
Auto collapse sidebar menu items

### DIFF
--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { NavLink, useLocation } from "react-router-dom";
 import {
   Calendar,
@@ -259,8 +259,8 @@ export function AppSidebar() {
   const toggleSubmenu = (title: string) => {
     setOpenSubmenus((prev) =>
       prev.includes(title)
-        ? prev.filter((item) => item !== title)
-        : [...prev, title]
+        ? []
+        : [title]
     );
   };
 
@@ -273,6 +273,27 @@ export function AppSidebar() {
     }
     return hasFeature(item.feature);
   };
+
+  useEffect(() => {
+    // Keep the parent of the active route expanded
+    const searchParams = new URLSearchParams(location.search);
+    const currentReportsTab = searchParams.get('tab') || 'overview';
+    const activeParent = menuItems.find((item) =>
+      item.subItems?.some((subItem) => {
+        if (item.title === 'Reports') {
+          return (
+            location.pathname === '/reports' &&
+            subItem.url.includes(`tab=${currentReportsTab}`)
+          );
+        }
+        return location.pathname === subItem.url;
+      })
+    );
+
+    if (activeParent) {
+      setOpenSubmenus([activeParent.title]);
+    }
+  }, [location.pathname, location.search]);
 
   return (
     <Sidebar variant="inset" collapsible="icon" className="border-r border-slate-200 max-w-[260px] md:max-w-[280px]">

--- a/src/components/layout/SuperAdminSidebar.tsx
+++ b/src/components/layout/SuperAdminSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { NavLink, useLocation } from "react-router-dom";
 import {
   Building,
@@ -138,10 +138,21 @@ export function SuperAdminSidebar() {
   const toggleSubmenu = (title: string) => {
     setOpenSubmenus((prev) =>
       prev.includes(title)
-        ? prev.filter((item) => item !== title)
-        : [...prev, title]
+        ? []
+        : [title]
     );
   };
+
+  useEffect(() => {
+    // Keep the parent of the active route expanded
+    const activeParent = superAdminMenuItems.find((item) =>
+      item.subItems?.some((subItem) => location.pathname === subItem.url)
+    );
+
+    if (activeParent) {
+      setOpenSubmenus([activeParent.title]);
+    }
+  }, [location.pathname]);
 
   return (
     <Sidebar variant="inset" collapsible="icon" className="border-r border-purple-200 max-w-[260px] md:max-w-[280px]">


### PR DESCRIPTION
Implement single-open accordion behavior for sidebar menus, ensuring only one parent menu is expanded at a time while keeping the active route's parent expanded.

---
<a href="https://cursor.com/background-agent?bcId=bc-f57b6024-56c4-4079-a4de-285241a32508">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f57b6024-56c4-4079-a4de-285241a32508">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

