### PR TITLE
Handle unique constraint error on adjustment approval

### DIFF
--- a/src/pages/InventoryAdjustments.tsx
+++ b/src/pages/InventoryAdjustments.tsx
@@ -230,13 +230,10 @@ export default function InventoryAdjustments() {
            // No existing level row => assume current was 0 and set to adjusted quantity
            try {
              const insertQuantity = item.adjusted_quantity ?? (item.difference ?? 0);
-             const { error: upsertErr } = await supabase
+             const { error: insertErr } = await supabase
                .from("inventory_levels")
-               .upsert(
-                 [{ item_id: item.item_id, warehouse_id: effectiveWarehouseId, quantity: insertQuantity }],
-                 { onConflict: "item_id,warehouse_id" }
-               );
-             if (upsertErr) throw upsertErr;
+               .insert([{ item_id: item.item_id, warehouse_id: effectiveWarehouseId, quantity: insertQuantity }]);
+             if (insertErr) throw insertErr;
            } catch (e: any) {
              // Convert FK violation into a clearer message
              const pgCode = e?.code || e?.details || "";
@@ -255,7 +252,7 @@ export default function InventoryAdjustments() {
           status: "approved",
           approved_at: new Date().toISOString(),
           approved_by: (await supabase.auth.getUser()).data.user?.id,
-          location_id: effectiveLocationId
+          warehouse_id: effectiveWarehouseId
         })
         .eq("id", adjustment.id);
 


### PR DESCRIPTION
Fixes 'no unique constraint' error on inventory adjustment approval by replacing `upsert` with `insert` and correcting the location ID field.

The original `upsert` on `inventory_levels` failed because the specified `onConflict` columns (`item_id,warehouse_id`) did not have a matching unique or exclusion constraint. Since the code path for new inventory levels already ensures no existing row, a direct `insert` is sufficient and resolves the error. Additionally, `effectiveLocationId` was undefined, so it was replaced with the correct `warehouse_id`.

---
<a href="https://cursor.com/background-agent?bcId=bc-350f4663-43c7-42d7-b681-490eaf3d5531">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-350f4663-43c7-42d7-b681-490eaf3d5531">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

