### PR TITLE
Fix useCallback hook rule violation

### DIFF
--- a/src/pages/Inventory.tsx
+++ b/src/pages/Inventory.tsx
@@ -421,6 +421,7 @@ export default function Inventory() {
 
   // Currency formatter
   const { format: formatMoney } = useOrganizationCurrency();
+  const formatRegionalNumber = useRegionalNumberFormatter();
 
   const fetchData = useCallback(async () => {
     setIsLoading(true);
@@ -749,7 +750,7 @@ export default function Inventory() {
             <CardTitle className="text-sm font-medium text-white/90">Quantities in Stock</CardTitle>
           </CardHeader>
           <CardContent className="relative">
-            <div className="text-2xl font-bold text-white">{useRegionalNumberFormatter()(totals.totalQty)}</div>
+            <div className="text-2xl font-bold text-white">{formatRegionalNumber(totals.totalQty)}</div>
             <p className="text-xs text-white/80">All products</p>
           </CardContent>
         </Card>
@@ -903,7 +904,7 @@ export default function Inventory() {
                                 <TableCell className="hidden lg:table-cell">{formatMoney(Number(item.cost_price || 0))}</TableCell>
                               )}
                               {visibleColumns.quantity && (
-                                <TableCell className="text-right">{useRegionalNumberFormatter()(itemIdToQty.get(item.id) || 0)}</TableCell>
+                                <TableCell className="text-right">{formatRegionalNumber(itemIdToQty.get(item.id) || 0)}</TableCell>
                               )}
                               {visibleColumns.reorder_point && (
                                 <TableCell className="hidden lg:table-cell">{item.reorder_point}</TableCell>

--- a/src/pages/ProductView.tsx
+++ b/src/pages/ProductView.tsx
@@ -76,6 +76,8 @@ export default function ProductView() {
   const [onHand, setOnHand] = useState<number>(0);
   const [levelsByWarehouse, setLevelsByWarehouse] = useState<Array<{ warehouse_id: string; quantity: number; warehouses?: { name: string } | null }>>([]);
   const { format: formatMoney } = useOrganizationCurrency();
+  const formatRegionalNumber = useRegionalNumberFormatter();
+  const formatDate = useRegionalDateFormatter();
 
   // Accounts mapping state
   const { organization } = useOrganization();
@@ -406,7 +408,7 @@ export default function ProductView() {
           <div className="grid grid-cols-1 md:grid-cols-5 gap-4">
             <div className="p-4 rounded-lg border bg-gradient-to-b from-white to-slate-50">
               <div className="text-xs text-muted-foreground">On Hand</div>
-              <div className="text-2xl font-semibold mt-1">{useRegionalNumberFormatter()(onHand)}</div>
+              <div className="text-2xl font-semibold mt-1">{formatRegionalNumber(onHand)}</div>
             </div>
             <div className="p-4 rounded-lg border bg-gradient-to-b from-white to-slate-50">
               <div className="text-xs text-muted-foreground">Purchased</div>
@@ -469,7 +471,7 @@ export default function ProductView() {
                     ) : (
                       usageHistory.map((row) => (
                         <TableRow key={row.id}>
-                          <TableCell>{useRegionalDateFormatter()(row.created_at)}</TableCell>
+                          <TableCell>{formatDate(row.created_at)}</TableCell>
                           <TableCell className="font-medium">{row.job_cards?.job_number || '—'}</TableCell>
                           <TableCell className="text-right">{row.quantity_used}</TableCell>
                           <TableCell className="hidden sm:table-cell text-right">{row.unit_cost ?? '—'}</TableCell>
@@ -510,7 +512,7 @@ export default function ProductView() {
                     ) : (
                       purchaseHistory.map((row) => (
                         <TableRow key={row.id}>
-                          <TableCell>{useRegionalDateFormatter()(row.created_at)}</TableCell>
+                          <TableCell>{formatDate(row.created_at)}</TableCell>
                           <TableCell className="font-medium">{row.purchases?.purchase_number || '—'}</TableCell>
                           <TableCell className="text-right">{row.quantity}</TableCell>
                           <TableCell className="hidden sm:table-cell text-right">{row.unit_cost ?? '—'}</TableCell>
@@ -552,7 +554,7 @@ export default function ProductView() {
                     ) : (
                       salesHistory.map((row) => (
                         <TableRow key={row.id}>
-                          <TableCell>{useRegionalDateFormatter()(row.created_at)}</TableCell>
+                          <TableCell>{formatDate(row.created_at)}</TableCell>
                           <TableCell className="font-medium">{row.sales?.sale_number || '—'}</TableCell>
                           <TableCell className="hidden md:table-cell">{row.sales?.customer_name || 'Walk-in Customer'}</TableCell>
                           <TableCell className="text-right">{row.quantity}</TableCell>


### PR DESCRIPTION
Hoist `useRegionalNumberFormatter` and `useRegionalDateFormatter` calls to fix "Rendered more hooks" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-1ce231ee-d5a7-44c6-8a75-ebe460c2801f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1ce231ee-d5a7-44c6-8a75-ebe460c2801f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

