### PR TITLE
Fetch user organizations on failure

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -21,14 +21,12 @@ function isValidUrl(url: string): boolean {
     return false
   }
 }
-const SUPABASE_URL = "https://eoxeoyyunhsdvjiwkttx.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVveGVveXl1bmhzZHZqaXdrdHR4Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM5NzI3NDUsImV4cCI6MjA2OTU0ODc0NX0.d3uazVxwI1_kPoF-QAGChcbfKS9PxwB536HrrlCXUrE";
+// Read Supabase configuration from Vite environment
+const RAW_SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL
+const RAW_SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY
 
-//const RAW_SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL
-//const RAW_SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY
-
-//const SUPABASE_URL = sanitizeEnv(RAW_SUPABASE_URL)
-//const SUPABASE_PUBLISHABLE_KEY = sanitizeEnv(RAW_SUPABASE_PUBLISHABLE_KEY)
+const SUPABASE_URL = sanitizeEnv(RAW_SUPABASE_URL)
+const SUPABASE_PUBLISHABLE_KEY = sanitizeEnv(RAW_SUPABASE_PUBLISHABLE_KEY)
 
 function createSupabaseStub() {
   const stubError = new Error(


### PR DESCRIPTION
Update Supabase client to use environment variables for URL and key to resolve 'Failed to fetch' errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-645a7c9c-fc9b-434f-a994-2871d87831c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-645a7c9c-fc9b-434f-a994-2871d87831c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

