### PR TITLE
Fetch organization users failed

### DIFF
--- a/src/pages/SuperAdmin.tsx
+++ b/src/pages/SuperAdmin.tsx
@@ -326,12 +326,40 @@ export default function SuperAdmin() {
         .eq('organization_id', organizationId)
         .order('created_at', { ascending: false });
 
-      if (error) throw error;
+      if (error) {
+        console.warn('Relational fetch for super admin organization users failed; attempting fallback without join', error)
+        const { data: memberships, error: membershipsError } = await supabase
+          .from('organization_users')
+          .select('id, organization_id, user_id, role, is_active, created_at, updated_at')
+          .eq('organization_id', organizationId)
+          .order('created_at', { ascending: false })
+        if (membershipsError) throw membershipsError
+
+        const userIds = Array.from(new Set((memberships || []).map((m: any) => m.user_id).filter(Boolean)))
+        let profilesByUserId: Record<string, any> = {}
+        if (userIds.length > 0) {
+          const { data: profiles, error: profilesError } = await supabase
+            .from('profiles')
+            .select('user_id, email, full_name')
+            .in('user_id', userIds)
+          if (profilesError) throw profilesError
+          profilesByUserId = Object.fromEntries((profiles || []).map((p: any) => [p.user_id, p]))
+        }
+
+        const formattedUsers = (memberships || []).map((user: any) => ({
+          ...user,
+          email: profilesByUserId[user.user_id]?.email || 'No email',
+          full_name: profilesByUserId[user.user_id]?.full_name || ''
+        }))
+
+        setOrgUsers(formattedUsers)
+        return
+      }
 
       const formattedUsers = data?.map(user => ({
         ...user,
-        email: user.profiles?.email || 'No email',
-        full_name: user.profiles?.full_name || ''
+        email: (user as any).profiles?.email || 'No email',
+        full_name: (user as any).profiles?.full_name || ''
       })) || [];
 
       setOrgUsers(formattedUsers);


### PR DESCRIPTION
Add robust fallbacks to prevent "Failed to fetch organization users" due to relational join issues.

When direct relational joins to `profiles` or `organizations` tables fail (e.g., due to RLS or missing foreign key metadata), the system now performs separate queries for the base `organization_users` data and then fetches the related `profiles` and `organizations` data, merging it to ensure the UI displays complete information without erroring. This applies to the SuperAdmin page, Admin Users page, and the SaaS `UserService.getOrganizationUsers`.

---
<a href="https://cursor.com/background-agent?bcId=bc-761aa6b4-05eb-42ae-8d2a-1587fdab3295">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-761aa6b4-05eb-42ae-8d2a-1587fdab3295">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

