### PR TITLE
Make view services details page wide

### DIFF
--- a/src/pages/ServiceView.tsx
+++ b/src/pages/ServiceView.tsx
@@ -200,7 +200,7 @@ export default function ServiceView() {
 
   return (
     <DashboardLayout>
-      <div className="flex-1 space-y-6 p-8 pt-6">
+      <div className="w-full max-w-7xl mx-auto p-6 space-y-6">
         {/* Service Header */}
         <Card className="mb-6">
           <CardContent className="pt-6">


### PR DESCRIPTION
Widen the Service details page to improve content display.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f7a7fde-344b-4ffb-9321-c6c926e517c4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7f7a7fde-344b-4ffb-9321-c6c926e517c4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

