### PR TITLE
Enlarge and left-align customer tab menus

### DIFF
--- a/src/pages/ClientProfile.tsx
+++ b/src/pages/ClientProfile.tsx
@@ -429,7 +429,7 @@ export default function ClientProfile() {
 
         {/* Tabs for different data views */}
         <Tabs defaultValue="appointments" className="space-y-4">
-          <TabsList>
+          <TabsList className="justify-start sm:justify-start rounded-xl border bg-card shadow-sm p-2 gap-2 h-auto [&_[role=tab]]:h-12 [&_[role=tab]]:px-4 [&_[role=tab]]:text-base [&_[role=tab]]:gap-2">
             <TabsTrigger value="appointments">Appointments</TabsTrigger>
             <TabsTrigger value="receipts">Sales Receipts</TabsTrigger>
             <TabsTrigger value="jobcards">Job Cards</TabsTrigger>


### PR DESCRIPTION
Make the tab menus on the Customer Details page larger and left-aligned.

---
<a href="https://cursor.com/background-agent?bcId=bc-f5abd596-0762-4d35-9340-5c9924d21f81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f5abd596-0762-4d35-9340-5c9924d21f81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

