### PR TITLE
Grant organization owner full admin rights

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -16,6 +16,7 @@ enum Role {
   ADMIN
   ACCOUNTANT
   INVENTORY
+  OWNER
 }
 
 enum AccountCategory {

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -16,6 +16,19 @@ async function main() {
     },
   });
 
+  // Also create an OWNER user for full admin rights testing
+  const ownerPasswordHash = await bcrypt.hash('owner123', 10);
+  await prisma.user.upsert({
+    where: { email: 'owner@example.com' },
+    update: {},
+    create: {
+      email: 'owner@example.com',
+      name: 'Owner User',
+      role: Role.OWNER,
+      passwordHash: ownerPasswordHash,
+    },
+  });
+
   // Core accounts
   const accounts = [
     { code: '1000', name: 'Cash', category: AccountCategory.ASSET },
@@ -63,6 +76,7 @@ async function main() {
   });
 
   console.log('Seed complete. Admin login: admin@example.com / admin123');
+  console.log('Seed complete. Owner login: owner@example.com / owner123');
 }
 
 main()

--- a/server/src/middleware/roles.ts
+++ b/server/src/middleware/roles.ts
@@ -1,10 +1,16 @@
 import { Request, Response, NextFunction } from 'express';
 
-export function requireRole(roles: Array<'ADMIN' | 'ACCOUNTANT' | 'INVENTORY'>) {
+export function requireRole(roles: Array<'ADMIN' | 'ACCOUNTANT' | 'INVENTORY' | 'OWNER'>) {
   return (req: Request, res: Response, next: NextFunction) => {
     const user = (req as any).user;
     if (!user) return res.status(401).json({ error: 'Unauthorized' });
-    if (!roles.includes(user.role)) return res.status(403).json({ error: 'Forbidden' });
+
+    const userRole = String(user.role || '').toUpperCase();
+
+    // Owners have full access
+    if (userRole === 'OWNER') return next();
+
+    if (!(roles as string[]).includes(userRole)) return res.status(403).json({ error: 'Forbidden' });
     next();
   };
 }


### PR DESCRIPTION
Grant server-side admin rights to Organization owners to align with frontend permissions.

The frontend already correctly grants full admin access to users with the 'owner' role. This PR updates the server-side `requireRole` middleware to also treat 'owner' as having full administrative privileges, ensuring consistent behavior across the application.

---
<a href="https://cursor.com/background-agent?bcId=bc-2d687433-e8d1-4f4e-8614-35041da05729">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2d687433-e8d1-4f4e-8614-35041da05729">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

