### PR TITLE
Create sales receipts from completed jobcards

### DIFF
--- a/src/utils/mockDatabase.ts
+++ b/src/utils/mockDatabase.ts
@@ -638,6 +638,7 @@ export async function updateReceiptWithFallback(supabase: any, id: string, updat
     if (typeof updates.total_amount !== 'undefined') allowed.total_amount = updates.total_amount;
     if (typeof updates.customer_id !== 'undefined') allowed.customer_id = updates.customer_id;
     if (typeof updates.job_card_id !== 'undefined') allowed.job_card_id = updates.job_card_id;
+    if (typeof updates.location_id !== 'undefined') allowed.location_id = updates.location_id;
 
     const { error } = await supabase
       .from('receipts')


### PR DESCRIPTION
Adds a job card lookup to the sales receipt form to prefill items, staff, commissions, customer, and location from completed job cards.

---
<a href="https://cursor.com/background-agent?bcId=bc-bdc7ad4a-0ba7-442c-a5ef-b148c21aa4be">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bdc7ad4a-0ba7-442c-a5ef-b148c21aa4be">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

