### PR TITLE
Fix clients listing page not displaying clients

### DIFF
--- a/src/pages/Clients.tsx
+++ b/src/pages/Clients.tsx
@@ -196,7 +196,16 @@ export default function Clients() {
         }
         const { data, error } = await query.order("created_at", { ascending: false });
         if (error) throw error;
-        setClients(data || []);
+
+        // If Supabase returns no rows, try fallback to local storage for demo/offline data
+        if (!data || data.length === 0) {
+          const storage = JSON.parse(localStorage.getItem('mockDb') || '{}');
+          const localClients = (storage.clients || []) as any[];
+          const filtered = organization?.id ? localClients.filter(c => c.organization_id === organization.id) : localClients;
+          setClients(filtered);
+        } else {
+          setClients(data || []);
+        }
       } catch (e: any) {
         // Fallback to local storage mock for demo/offline
         const storage = JSON.parse(localStorage.getItem('mockDb') || '{}');


### PR DESCRIPTION
Ensure clients are displayed on the Clients Listing page by falling back to local storage data when the Supabase query returns an empty result.

Previously, the client list only fell back to local storage upon a Supabase query error. This change extends the fallback to cases where the Supabase query returns an empty array, ensuring clients are still displayed from local mock data in "empty-but-no-error" scenarios.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e1fdcd9-d793-4e0f-ba2f-5de2665e4afe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8e1fdcd9-d793-4e0f-ba2f-5de2665e4afe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

