### PR TITLE
Fix product account saving bug

### DIFF
--- a/setup_database.sql
+++ b/setup_database.sql
@@ -3,6 +3,12 @@
 
 -- 1. Run the complete schema migration
 \i supabase/migrations/20250116000004_complete_database_schema.sql
+\i supabase/migrations/20250812090000_add_business_locations_and_location_filters.sql
+\i supabase/migrations/20250827093000_purchase_receiving_and_payments.sql
+\i supabase/migrations/20250902091500_goods_received_tables.sql
+\i supabase/migrations/20250915093000_inventory_transfers.sql
+\i supabase/migrations/20250916094500_inventory_adjustments.sql
+\i supabase/migrations/20250917094500_inventory_item_accounts.sql
 
 -- Replace invoices with receipts (ensures receipts exist before adding location_id)
 \i supabase/migrations/20250809000000_replace_invoices_with_receipts.sql

--- a/src/pages/Inventory.tsx
+++ b/src/pages/Inventory.tsx
@@ -534,9 +534,11 @@ export default function Inventory() {
               .eq('item_id', editingItem.id)
               .maybeSingle();
             if (existing) {
-              await supabase.from('inventory_item_accounts').update(payload).eq('item_id', editingItem.id);
+              const { error } = await supabase.from('inventory_item_accounts').update(payload).eq('item_id', editingItem.id);
+              if (error) throw error;
             } else {
-              await supabase.from('inventory_item_accounts').insert(payload);
+              const { error } = await supabase.from('inventory_item_accounts').insert(payload);
+              if (error) throw error;
             }
           }
         }
@@ -583,9 +585,11 @@ export default function Inventory() {
                 .eq('item_id', newItemId)
                 .maybeSingle();
               if (existing) {
-                await supabase.from('inventory_item_accounts').update(payload).eq('item_id', newItemId);
+                const { error } = await supabase.from('inventory_item_accounts').update(payload).eq('item_id', newItemId);
+                if (error) throw error;
               } else {
-                await supabase.from('inventory_item_accounts').insert(payload);
+                const { error } = await supabase.from('inventory_item_accounts').insert(payload);
+                if (error) throw error;
               }
             }
           }
@@ -604,8 +608,8 @@ export default function Inventory() {
       setIsItemDialogOpen(false);
       setEditingItem(null);
       fetchData();
-    } catch (error) {
-      toast({ title: "Error", description: "Failed to save product", variant: "destructive" });
+    } catch (error: any) {
+      toast({ title: "Error", description: String(error?.message || error || 'Failed to save product'), variant: "destructive" });
     }
   };
 

--- a/supabase/migrations/20250917094500_inventory_item_accounts.sql
+++ b/supabase/migrations/20250917094500_inventory_item_accounts.sql
@@ -1,0 +1,49 @@
+-- Inventory item account mappings (per-product accounts)
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS public.inventory_item_accounts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  item_id UUID NOT NULL REFERENCES public.inventory_items(id) ON DELETE CASCADE,
+  sales_account_id UUID REFERENCES public.accounts(id) ON DELETE SET NULL,
+  purchase_account_id UUID REFERENCES public.accounts(id) ON DELETE SET NULL,
+  inventory_account_id UUID REFERENCES public.accounts(id) ON DELETE SET NULL,
+  is_taxable BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Unique mapping per item (supports upsert onConflict: 'item_id')
+CREATE UNIQUE INDEX IF NOT EXISTS ux_inventory_item_accounts_item ON public.inventory_item_accounts(item_id);
+
+-- Helpful lookup indexes
+CREATE INDEX IF NOT EXISTS idx_inventory_item_accounts_sales_acc ON public.inventory_item_accounts(sales_account_id);
+CREATE INDEX IF NOT EXISTS idx_inventory_item_accounts_purchase_acc ON public.inventory_item_accounts(purchase_account_id);
+CREATE INDEX IF NOT EXISTS idx_inventory_item_accounts_inventory_acc ON public.inventory_item_accounts(inventory_account_id);
+
+-- Reuse generic updated_at trigger if present
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END; $$ LANGUAGE plpgsql;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_inventory_item_accounts_updated_at') THEN
+    CREATE TRIGGER trg_inventory_item_accounts_updated_at BEFORE UPDATE ON public.inventory_item_accounts
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+  END IF;
+END $$;
+
+-- Enable RLS and allow all for dev/demo (adjust in production)
+ALTER TABLE public.inventory_item_accounts ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies 
+    WHERE schemaname = 'public' AND tablename = 'inventory_item_accounts' AND policyname = 'Allow all (inventory_item_accounts)'
+  ) THEN
+    CREATE POLICY "Allow all (inventory_item_accounts)" ON public.inventory_item_accounts
+      FOR ALL TO anon, authenticated USING (true) WITH CHECK (true);
+  END IF;
+END $$;


### PR DESCRIPTION
Adds the `inventory_item_accounts` table migration and improves frontend error handling to fix product accounting details not saving.

The `inventory_item_accounts` table, which stores product-specific sales, purchase, and inventory account mappings, was missing from the database schema. This caused Supabase upsert operations to fail silently. This PR introduces the table with a unique `item_id` constraint for correct upsert behavior and adds UI toasts to surface save errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-1fdf90dc-4a44-4380-8420-2eaa36e1f5e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1fdf90dc-4a44-4380-8420-2eaa36e1f5e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

