### PR TITLE
Make accounts fields mandatory for inventory and services

### DIFF
--- a/src/pages/Inventory.tsx
+++ b/src/pages/Inventory.tsx
@@ -62,6 +62,7 @@ const ItemFormDialog = ({ isOpen, onClose, onSubmit, editingItem, warehouses }: 
   const [incomeAccounts, setIncomeAccounts] = useState<any[]>([]);
   const [expenseAccounts, setExpenseAccounts] = useState<any[]>([]);
   const [assetAccounts, setAssetAccounts] = useState<any[]>([]);
+  const [errors, setErrors] = useState<{ sales?: string; purchase?: string; inventory?: string }>({});
 
   useEffect(() => {
     if (editingItem) {
@@ -80,6 +81,7 @@ const ItemFormDialog = ({ isOpen, onClose, onSubmit, editingItem, warehouses }: 
         opening_stock_quantity: 0,
         opening_stock_warehouse_id: "",
       });
+      setErrors({});
     } else {
       setFormData({
         name: "",
@@ -96,6 +98,7 @@ const ItemFormDialog = ({ isOpen, onClose, onSubmit, editingItem, warehouses }: 
         opening_stock_quantity: 0,
         opening_stock_warehouse_id: "",
       });
+      setErrors({});
     }
   }, [editingItem]);
 
@@ -161,6 +164,15 @@ const ItemFormDialog = ({ isOpen, onClose, onSubmit, editingItem, warehouses }: 
 
   const handleFormSubmit = (e) => {
     e.preventDefault();
+    const nextErrors: { sales?: string; purchase?: string; inventory?: string } = {};
+    if (!formData.sales_account_id) nextErrors.sales = "Required";
+    if (!formData.purchase_account_id) nextErrors.purchase = "Required";
+    if (!formData.inventory_account_id) nextErrors.inventory = "Required";
+    setErrors(nextErrors);
+    if (nextErrors.sales || nextErrors.purchase || nextErrors.inventory) {
+      toast({ title: "Missing accounts", description: "Please select Sales, Purchase, and Inventory accounts.", variant: "destructive" });
+      return;
+    }
     // Ensure numeric fields are numbers
     const payload = {
       ...formData,
@@ -300,6 +312,7 @@ const ItemFormDialog = ({ isOpen, onClose, onSubmit, editingItem, warehouses }: 
                   ))}
                 </SelectContent>
               </Select>
+              {errors.sales && (<p className="text-xs text-destructive">{errors.sales}</p>)}
             </div>
             <div className="space-y-2">
               <Label>Purchase Account</Label>
@@ -316,6 +329,7 @@ const ItemFormDialog = ({ isOpen, onClose, onSubmit, editingItem, warehouses }: 
                   ))}
                 </SelectContent>
               </Select>
+              {errors.purchase && (<p className="text-xs text-destructive">{errors.purchase}</p>)}
             </div>
             <div className="space-y-2">
               <Label>Inventory Account</Label>
@@ -332,6 +346,7 @@ const ItemFormDialog = ({ isOpen, onClose, onSubmit, editingItem, warehouses }: 
                   ))}
                 </SelectContent>
               </Select>
+              {errors.inventory && (<p className="text-xs text-destructive">{errors.inventory}</p>)}
             </div>
           </div>
 
@@ -500,6 +515,10 @@ export default function Inventory() {
 
   const handleItemSubmit = async (formData) => {
     try {
+      if (!formData.sales_account_id || !formData.purchase_account_id || !formData.inventory_account_id) {
+        toast({ title: "Missing accounts", description: "Please select Sales, Purchase, and Inventory accounts.", variant: "destructive" });
+        return;
+      }
       if (editingItem) {
         const { error } = await supabase.from("inventory_items").update({
           name: formData.name,

--- a/src/pages/ProductView.tsx
+++ b/src/pages/ProductView.tsx
@@ -95,6 +95,7 @@ export default function ProductView() {
     inventory_account_id: "",
     is_taxable: false,
   });
+  const [accountErrors, setAccountErrors] = useState<{ sales?: string; purchase?: string; inventory?: string }>({});
 
   useEffect(() => {
     const load = async () => {
@@ -247,6 +248,15 @@ export default function ProductView() {
   const saveAccounts = async () => {
     if (!id) return;
     try {
+      const nextErrors: { sales?: string; purchase?: string; inventory?: string } = {};
+      if (!editForm.sales_account_id) nextErrors.sales = "Required";
+      if (!editForm.purchase_account_id) nextErrors.purchase = "Required";
+      if (!editForm.inventory_account_id) nextErrors.inventory = "Required";
+      setAccountErrors(nextErrors);
+      if (nextErrors.sales || nextErrors.purchase || nextErrors.inventory) {
+        toast({ title: "Missing accounts", description: "Please select Sales, Purchase, and Inventory accounts.", variant: "destructive" });
+        return;
+      }
       const payload = {
         item_id: id,
         sales_account_id: editForm.sales_account_id || null,
@@ -285,6 +295,7 @@ export default function ProductView() {
       }
 
       setIsEditAccountsOpen(false);
+      setAccountErrors({});
       // reload mapping
       const { data: mapData, error: reloadError } = await supabase
         .from("inventory_item_accounts")
@@ -666,6 +677,7 @@ export default function ProductView() {
                   ))}
                 </SelectContent>
               </Select>
+              {accountErrors.sales && (<p className="text-xs text-destructive">{accountErrors.sales}</p>)}
             </div>
             <div className="space-y-2">
               <Label>Purchase Account</Label>
@@ -682,6 +694,7 @@ export default function ProductView() {
                   ))}
                 </SelectContent>
               </Select>
+              {accountErrors.purchase && (<p className="text-xs text-destructive">{accountErrors.purchase}</p>)}
             </div>
             <div className="space-y-2">
               <Label>Inventory Account</Label>
@@ -698,6 +711,7 @@ export default function ProductView() {
                   ))}
                 </SelectContent>
               </Select>
+              {accountErrors.inventory && (<p className="text-xs text-destructive">{accountErrors.inventory}</p>)}
             </div>
             <div className="space-y-2">
               <Label>Taxable</Label>


### PR DESCRIPTION
Make Sales, Purchase, and Inventory account fields mandatory when creating or editing inventory items.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc5a28f0-3c60-468f-a4c3-903ce9c8a762">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dc5a28f0-3c60-468f-a4c3-903ce9c8a762">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

