### PR TITLE
Fix select item value prop

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1421,14 +1421,15 @@ phone: "",
                           <TableCell className="text-muted-foreground">{location.description}</TableCell>
                           <TableCell>
                             <Select
-                              value={location.default_warehouse_id || ""}
+                              value={location.default_warehouse_id ?? "__none__"}
                               onValueChange={async (val) => {
                                 try {
+                                  const next = val === "__none__" ? null : val
                                   await supabase
                                     .from('business_locations')
-                                    .update({ default_warehouse_id: val || null })
+                                    .update({ default_warehouse_id: next })
                                     .eq('id', location.id);
-                                  setStockLocations(prev => prev.map(l => l.id === location.id ? { ...l, default_warehouse_id: val || null } : l));
+                                  setStockLocations(prev => prev.map(l => l.id === location.id ? { ...l, default_warehouse_id: next } : l));
                                   toast.success('Default warehouse updated');
                                 } catch (e) {
                                   console.error(e);
@@ -1440,7 +1441,7 @@ phone: "",
                                 <SelectValue placeholder="Select default warehouse" />
                               </SelectTrigger>
                               <SelectContent>
-                                <SelectItem value="">— None —</SelectItem>
+                                <SelectItem value="__none__">— None —</SelectItem>
                                 {warehouses
                                   .filter(w => w.is_active)
                                   .map(w => (
@@ -1484,14 +1485,14 @@ phone: "",
                       <div className="space-y-2">
                         <Label>Default Warehouse</Label>
                         <Select
-                          value={locationForm.default_warehouse_id}
-                          onValueChange={(v) => setLocationForm(prev => ({ ...prev, default_warehouse_id: v }))}
+                          value={locationForm.default_warehouse_id || ""}
+                          onValueChange={(v) => setLocationForm(prev => ({ ...prev, default_warehouse_id: v === "__none__" ? null : v }))}
                         >
                           <SelectTrigger>
                             <SelectValue placeholder="Select a default warehouse (optional)" />
                           </SelectTrigger>
                           <SelectContent>
-                            <SelectItem value="">— None —</SelectItem>
+                            <SelectItem value="__none__">— None —</SelectItem>
                             {warehouses.filter(w => w.is_active).map(w => (
                               <SelectItem key={w.id} value={w.id}>{w.name}</SelectItem>
                             ))}


### PR DESCRIPTION
Fixes Radix UI error by replacing empty string `value` in `Select.Item` with a sentinel.

The `__none__` sentinel is used for the "— None —" option, which is mapped to `null` when saving to the database or updating form state. The `Select` component's `value` prop now correctly displays the sentinel when the actual value is `null`.

---
<a href="https://cursor.com/background-agent?bcId=bc-059be2a9-c6a1-4335-b543-3420dc1efd75">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-059be2a9-c6a1-4335-b543-3420dc1efd75">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

