### PR TITLE
Fix select item value prop

### DIFF
--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -109,27 +109,48 @@ const SelectLabel = React.forwardRef<
 ))
 SelectLabel.displayName = SelectPrimitive.Label.displayName
 
+// Coerce value to a non-empty string to satisfy Radix requirements
+// and disable the item if the provided value is missing/empty.
 const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => (
-  <SelectPrimitive.Item
-    ref={ref}
-    className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      className
-    )}
-    {...props}
-  >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <SelectPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
-      </SelectPrimitive.ItemIndicator>
-    </span>
+  Omit<React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>, "value"> & {
+    value: string | number
+  }
+>(({ className, children, value, disabled, ...props }, ref) => {
+  const coerced = value === null || value === undefined ? "" : String(value)
+  const trimmed = coerced.trim()
+  const isInvalid = trimmed.length === 0
+  const safeValue = isInvalid ? "__invalid__" : trimmed
 
-    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-  </SelectPrimitive.Item>
-))
+  if (isInvalid && process.env.NODE_ENV !== "production") {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "SelectItem received an empty value. Disabling item and substituting a sentinel to avoid Radix error.",
+      { value }
+    )
+  }
+
+  return (
+    <SelectPrimitive.Item
+      ref={ref}
+      value={safeValue}
+      disabled={disabled || isInvalid}
+      className={cn(
+        "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <Check className="h-4 w-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+})
 SelectItem.displayName = SelectPrimitive.Item.displayName
 
 const SelectSeparator = React.forwardRef<


### PR DESCRIPTION
Modify `SelectItem` to coerce values to non-empty strings and disable items with invalid values to prevent Radix UI runtime errors.

The original error occurred when `Select.Item` received an empty string or `undefined` as its `value` prop, which Radix UI explicitly disallows. This PR defensively wraps `Select.Item` to ensure that any incoming `value` is coerced to a valid non-empty string, and if it's still empty, the item is disabled and a sentinel value is used to avoid crashing the application. This ensures robustness without requiring every usage site to pre-validate values.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe0ce68e-4e54-4a6b-b2f4-dfb06b261382">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fe0ce68e-4e54-4a6b-b2f4-dfb06b261382">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

