### PR TITLE
Fix unrecognized datetime type in database

### DIFF
--- a/server/prisma/migrations/20250812184447_init/migration.sql
+++ b/server/prisma/migrations/20250812184447_init/migration.sql
@@ -1,3 +1,6 @@
+-- Create compatibility alias so DATETIME works on PostgreSQL
+CREATE DOMAIN DATETIME AS TIMESTAMPTZ;
+
 -- CreateTable
 CREATE TABLE "User" (
     "id" TEXT NOT NULL PRIMARY KEY,


### PR DESCRIPTION
Add a PostgreSQL compatibility alias for `DATETIME` to resolve migration errors.

The `DATETIME` type is specific to SQLite, and PostgreSQL does not natively support it, leading to a "type datetime does not exist" error when applying SQLite-generated migrations to a PostgreSQL database. This change creates a `DATETIME` domain as an alias for `TIMESTAMPTZ` in PostgreSQL, allowing the migration to run successfully without modifying all occurrences of `DATETIME`.

---
<a href="https://cursor.com/background-agent?bcId=bc-44864b83-d52b-4c7e-b38b-a714353ac919">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-44864b83-d52b-4c7e-b38b-a714353ac919">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

