### PR TITLE
Fix warehouse visibility and prevent deletion

### DIFF
--- a/supabase/migrations/20250920120000_prevent_warehouse_delete_with_transactions.sql
+++ b/supabase/migrations/20250920120000_prevent_warehouse_delete_with_transactions.sql
@@ -1,0 +1,27 @@
+-- Prevent deleting warehouses that have related transactions
+CREATE OR REPLACE FUNCTION public.prevent_warehouse_delete_if_referenced()
+RETURNS trigger AS $$
+BEGIN
+  -- Block deletion if any transaction-like records reference this warehouse
+  IF EXISTS (SELECT 1 FROM public.inventory_levels WHERE warehouse_id = OLD.id) THEN
+    RAISE EXCEPTION 'Cannot delete warehouse with existing inventory levels or transactions referencing it';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM public.goods_received WHERE warehouse_id = OLD.id) THEN
+    RAISE EXCEPTION 'Cannot delete warehouse with goods received referencing it';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM public.inventory_adjustments WHERE warehouse_id = OLD.id) THEN
+    RAISE EXCEPTION 'Cannot delete warehouse with inventory adjustments referencing it';
+  END IF;
+
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Ensure trigger exists
+DROP TRIGGER IF EXISTS trg_prevent_warehouse_delete ON public.warehouses;
+CREATE TRIGGER trg_prevent_warehouse_delete
+BEFORE DELETE ON public.warehouses
+FOR EACH ROW
+EXECUTE FUNCTION public.prevent_warehouse_delete_if_referenced();


### PR DESCRIPTION
Fixes warehouse listing to always show newly created warehouses and prevents deletion of warehouses with existing transactions.

The previous warehouse listing logic had a conditional filter that could prevent newly created warehouses from appearing if an organization ID was not consistently applied or if `is_active` was used instead. This PR ensures `organization_id` is always used for filtering and required for creation. Additionally, to maintain data integrity, warehouses with associated `inventory_levels`, `goods_received`, or `inventory_adjustments` can no longer be deleted, a restriction enforced both in the UI and via a new database trigger.

---
<a href="https://cursor.com/background-agent?bcId=bc-ecf9aa17-73e0-4465-80f1-6ab475ca7ae1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ecf9aa17-73e0-4465-80f1-6ab475ca7ae1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

