### PR TITLE
Fix missing updated_at field on warehouse save

### DIFF
--- a/setup_database.sql
+++ b/setup_database.sql
@@ -36,6 +36,8 @@
 \i supabase/migrations/20250910094500_add_commission_rate_to_staff.sql
 -- Add default warehouse for business locations
 \i supabase/migrations/20250915090000_add_default_warehouse_to_business_locations.sql
+-- Ensure warehouses has updated_at and trigger
+\i supabase/migrations/20250921101000_fix_warehouses_updated_at.sql
 
 -- 2. Ensure all required functions exist
 -- Create organization creation function if it doesn't exist

--- a/supabase/migrations/20250921101000_fix_warehouses_updated_at.sql
+++ b/supabase/migrations/20250921101000_fix_warehouses_updated_at.sql
@@ -1,0 +1,33 @@
+-- Ensure warehouses has updated_at and trigger
+DO $$
+BEGIN
+  -- Add updated_at column if it does not exist
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'warehouses'
+      AND column_name = 'updated_at'
+  ) THEN
+    ALTER TABLE public.warehouses
+      ADD COLUMN updated_at timestamptz NOT NULL DEFAULT now();
+  END IF;
+END $$;
+
+-- Generic updated_at trigger function (idempotent)
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END; $$ LANGUAGE plpgsql;
+
+-- Ensure trigger exists on warehouses
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'trg_warehouses_updated_at'
+  ) THEN
+    CREATE TRIGGER trg_warehouses_updated_at
+    BEFORE UPDATE ON public.warehouses
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+  END IF;
+END $$;


### PR DESCRIPTION
Adds `updated_at` column and its trigger to `public.warehouses` to resolve "record 'new' has no field 'updated_at'" errors.

The database had a `BEFORE UPDATE` trigger expecting an `updated_at` column on `public.warehouses`, but the column was missing, causing save operations to fail. This PR ensures the column and its trigger are present.

---
<a href="https://cursor.com/background-agent?bcId=bc-47d0828c-dfd7-423c-a619-e0a8d51556e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-47d0828c-dfd7-423c-a619-e0a8d51556e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

