### PR TITLE
Fix invoices toLowerCase undefined error

### DIFF
--- a/src/pages/Invoices.tsx
+++ b/src/pages/Invoices.tsx
@@ -643,8 +643,9 @@ export default function Invoices() {
   };
 
   const filteredInvoices = invoices.filter(invoice => {
-    const matchesSearch = invoice.invoice_number.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                         invoice.customer_name.toLowerCase().includes(searchTerm.toLowerCase());
+    const normalizedSearch = (searchTerm || "").toLowerCase();
+    const matchesSearch = ((invoice.invoice_number || "").toLowerCase().includes(normalizedSearch)) ||
+                         ((invoice.customer_name || "").toLowerCase().includes(normalizedSearch));
     const matchesStatus = statusFilter === "all" || invoice.status === statusFilter;
     return matchesSearch && matchesStatus;
   });


### PR DESCRIPTION
Add null-safe checks to invoice search filters to prevent `TypeError` when `invoice_number`, `customer_name`, or `searchTerm` are undefined.

---
<a href="https://cursor.com/background-agent?bcId=bc-cc31ed99-59e6-4e4a-aa20-a162676c4215">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cc31ed99-59e6-4e4a-aa20-a162676c4215">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

