### PR TITLE
Show transaction number for mobile money

### DIFF
--- a/src/pages/POS.tsx
+++ b/src/pages/POS.tsx
@@ -65,6 +65,7 @@ const PAYMENT_METHODS = [
   "Cash",
   "Credit Card", 
   "Debit Card",
+  "Mobile money",
   "Mobile Payment",
   "Bank Transfer",
   "Store Credit"
@@ -93,6 +94,7 @@ export default function POS() {
     tax_percentage: 8.5, // Default tax rate
     notes: "",
     cash_received: "",
+    transaction_number: "",
   });
   const [applyTax, setApplyTax] = useState<boolean>(false);
 
@@ -312,6 +314,7 @@ export default function POS() {
       tax_percentage: 8.5,
       notes: "",
       cash_received: "",
+      transaction_number: "",
     });
   };
 
@@ -364,7 +367,9 @@ export default function POS() {
         total_amount: totals.total,
         payment_method: paymentData.payment_method,
         status: "completed",
-        notes: paymentData.notes || null,
+        notes: (paymentData.notes || paymentData.transaction_number) 
+          ? `${paymentData.notes || ""}${paymentData.notes && paymentData.transaction_number ? "\n" : ""}${paymentData.transaction_number ? `Transaction #: ${paymentData.transaction_number}` : ""}` 
+          : null,
       };
 
       // Use fallback function to handle missing database tables
@@ -784,6 +789,19 @@ export default function POS() {
                             Change: {formatMoney(parseFloat(paymentData.cash_received) - totals.total)}
                           </p>
                         )}
+                      </div>
+                    )}
+
+                    {(paymentData.payment_method === "Mobile money" || paymentData.payment_method === "Mobile Payment") && (
+                      <div>
+                        <Label htmlFor="transaction_number">Transaction Number</Label>
+                        <Input
+                          id="transaction_number"
+                          type="text"
+                          value={paymentData.transaction_number}
+                          onChange={(e) => setPaymentData({ ...paymentData, transaction_number: e.target.value })}
+                          placeholder="e.g. M-Pesa/Mobile money ref"
+                        />
                       </div>
                     )}
 


### PR DESCRIPTION
Adds a conditional 'Transaction Number' field to the POS checkout payment modal for mobile money payments.

---
<a href="https://cursor.com/background-agent?bcId=bc-8cd36ecf-9147-4392-a54d-bb9a67f2e0e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8cd36ecf-9147-4392-a54d-bb9a67f2e0e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

