### PR TITLE
Fix inability to save new product items

### DIFF
--- a/src/pages/Inventory.tsx
+++ b/src/pages/Inventory.tsx
@@ -521,10 +521,10 @@ export default function Inventory() {
       }
       if (editingItem) {
         const { error } = await supabase.from("inventory_items").update({
-          name: formData.name,
+          name: (formData.name || '').trim(),
           description: formData.description,
-          sku: formData.sku,
-          unit: formData.unit,
+          sku: (formData.sku || '').trim() ? (formData.sku || '').trim() : null,
+          unit: (formData.unit || '').trim() || null,
           reorder_point: formData.reorder_point,
           cost_price: formData.cost_price,
           selling_price: formData.selling_price,
@@ -567,10 +567,10 @@ export default function Inventory() {
         const { data: inserted, error } = await supabase
           .from("inventory_items")
           .insert({
-            name: payload.name,
+            name: (payload.name || '').trim(),
             description: payload.description,
-            sku: payload.sku,
-            unit: payload.unit,
+            sku: (payload.sku || '').trim() ? (payload.sku || '').trim() : null,
+            unit: (payload.unit || '').trim() || null,
             reorder_point: payload.reorder_point,
             cost_price: payload.cost_price,
             selling_price: payload.selling_price,

--- a/src/pages/ProductForm.tsx
+++ b/src/pages/ProductForm.tsx
@@ -121,10 +121,10 @@ export default function ProductForm() {
       const { data: inserted, error } = await supabase
         .from("inventory_items")
         .insert({
-          name: payload.name,
+          name: (payload.name || '').trim(),
           description: payload.description,
-          sku: payload.sku,
-          unit: payload.unit,
+          sku: (payload.sku || '').trim() ? (payload.sku || '').trim() : null,
+          unit: (payload.unit || '').trim() || null,
           reorder_point: payload.reorder_point,
           cost_price: payload.cost_price,
           selling_price: payload.selling_price,


### PR DESCRIPTION
Normalize empty SKUs to null and trim text fields to fix saving new Product Items.

This prevents unique constraint errors on the `sku` column when multiple product items are created with an empty or whitespace-only SKU, as an empty string `''` is treated as a unique value, while `null` is not.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a71f617-729c-47f0-87d2-6694a7b9c8e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6a71f617-729c-47f0-87d2-6694a7b9c8e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

