### PR TITLE
Add auto-filled location field to invoice

### DIFF
--- a/src/utils/mockDatabase.ts
+++ b/src/utils/mockDatabase.ts
@@ -475,7 +475,7 @@ export async function createInvoiceWithFallback(supabase: any, invoiceData: any,
       service_id: item.service_id || null,
       product_id: item.product_id || null,
       staff_id: item.staff_id || null,
-      location_id: item.location_id || null,
+      location_id: (item.location_id ?? dbInvoice.location_id) || null,
       commission_percentage: typeof item.commission_percentage === 'number' ? item.commission_percentage : null,
       commission_amount: typeof item.commission_percentage === 'number'
         ? Number(((item.commission_percentage / 100) * (item.total_price ?? (item.quantity * item.unit_price))).toFixed(2))
@@ -568,6 +568,7 @@ export async function getInvoicesWithFallback(supabase: any) {
         jobcard_id: null,
         created_at: inv.created_at,
         updated_at: inv.updated_at,
+        location_id: inv.location_id ?? null,
       }));
     }
 
@@ -589,7 +590,7 @@ export async function getInvoicesWithFallback(supabase: any) {
       payment_method: null,
       notes: r.notes || null,
       jobcard_id: null,
-
+      location_id: r.location_id ?? null,
     }));
   } catch (error) {
     console.log('Using mock database for invoices');
@@ -613,6 +614,7 @@ export async function getInvoicesWithFallback(supabase: any) {
       jobcard_id: null,
       created_at: r.created_at,
       updated_at: r.updated_at,
+      location_id: r.location_id ?? null,
     }));
   }
 }

--- a/supabase/migrations/20250923093000_add_location_columns_to_invoices.sql
+++ b/supabase/migrations/20250923093000_add_location_columns_to_invoices.sql
@@ -1,0 +1,56 @@
+-- Add location_id to invoices and invoice_items, with safe guards and indexes
+DO $$
+BEGIN
+  -- invoices.location_id
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'invoices' AND column_name = 'location_id'
+  ) THEN
+    ALTER TABLE public.invoices ADD COLUMN location_id uuid NULL;
+  END IF;
+
+  -- invoice_items.location_id
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'invoice_items' AND column_name = 'location_id'
+  ) THEN
+    ALTER TABLE public.invoice_items ADD COLUMN location_id uuid NULL;
+  END IF;
+END $$;
+
+-- Add FKs if business_locations exists
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables 
+    WHERE table_schema = 'public' AND table_name = 'business_locations'
+  ) THEN
+    -- invoices FK
+    IF NOT EXISTS (
+      SELECT 1 
+      FROM information_schema.table_constraints tc
+      WHERE tc.table_schema = 'public' AND tc.table_name = 'invoices' AND tc.constraint_type = 'FOREIGN KEY'
+        AND tc.constraint_name = 'invoices_location_id_fkey'
+    ) THEN
+      ALTER TABLE public.invoices
+        ADD CONSTRAINT invoices_location_id_fkey
+        FOREIGN KEY (location_id) REFERENCES public.business_locations(id) ON DELETE SET NULL;
+    END IF;
+
+    -- invoice_items FK
+    IF NOT EXISTS (
+      SELECT 1 
+      FROM information_schema.table_constraints tc
+      WHERE tc.table_schema = 'public' AND tc.table_name = 'invoice_items' AND tc.constraint_type = 'FOREIGN KEY'
+        AND tc.constraint_name = 'invoice_items_location_id_fkey'
+    ) THEN
+      ALTER TABLE public.invoice_items
+        ADD CONSTRAINT invoice_items_location_id_fkey
+        FOREIGN KEY (location_id) REFERENCES public.business_locations(id) ON DELETE SET NULL;
+    END IF;
+  END IF;
+END $$;
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_invoices_location_id ON public.invoices(location_id);
+CREATE INDEX IF NOT EXISTS idx_invoice_items_location_id ON public.invoice_items(location_id);


### PR DESCRIPTION
Add `location_id` to invoices and invoice items, enabling auto-prefill and persistence of invoice location.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae8100cf-cc15-46e0-861a-3b97db8fb576">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ae8100cf-cc15-46e0-861a-3b97db8fb576">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

