### PR TITLE
Fix services page not displaying all services

### DIFF
--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -187,7 +187,7 @@ export default function Services() {
         const { data, error } = await supabase
           .from("services")
           .select("*")
-          .eq("organization_id", organization.id)
+          .or(`organization_id.eq.${organization.id},organization_id.is.null`)
           .order("created_at", { ascending: false });
 
         if (error) {


### PR DESCRIPTION
Update Services page query to display all services, including those without an organization ID.

---
<a href="https://cursor.com/background-agent?bcId=bc-e25df7de-3977-443b-9ea8-40e779c11327">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e25df7de-3977-443b-9ea8-40e779c11327">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

