### PR TITLE
Make staff view page wide and responsive

### DIFF
--- a/src/pages/StaffProfile.tsx
+++ b/src/pages/StaffProfile.tsx
@@ -336,7 +336,7 @@ export default function StaffProfile() {
   if (!staff) return <div className="p-6">Staff not found</div>;
 
   return (
-    <div className="flex-1 space-y-6 px-4 sm:px-6 lg:px-8 py-6 bg-gradient-to-br from-slate-50 to-slate-100/50 min-h-screen max-w-screen-2xl mx-auto w-full">
+    <div className="flex-1 space-y-6 px-4 sm:px-6 lg:px-8 py-6 bg-gradient-to-br from-slate-50 to-slate-100/50 min-h-screen w-full">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3 min-w-0 flex-1">
           <Button variant="outline" onClick={() => navigate(-1)}>


### PR DESCRIPTION
Make the Staff View page wide and responsive by removing its max-width constraint.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ff20762-a091-4085-97a6-f625bf2afaad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8ff20762-a091-4085-97a6-f625bf2afaad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

