### PR TITLE
Rearrange staff profile view tabs

### DIFF
--- a/src/pages/StaffProfile.tsx
+++ b/src/pages/StaffProfile.tsx
@@ -472,9 +472,9 @@ export default function StaffProfile() {
           <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-4">
             <div className="overflow-x-auto -mx-1 px-1">
               <TabsList className="min-w-max justify-start sm:justify-start">
-                <TabsTrigger value="commissions" className="px-4 py-2 text-base">Commissions</TabsTrigger>
-                <TabsTrigger value="activity" className="px-4 py-2 text-base">Activity</TabsTrigger>
+                <TabsTrigger value="activity" className="px-4 py-2 text-base">Activities</TabsTrigger>
                 <TabsTrigger value="schedule" className="px-4 py-2 text-base">Schedule</TabsTrigger>
+                <TabsTrigger value="commissions" className="px-4 py-2 text-base">Commissions</TabsTrigger>
                 <TabsTrigger value="gallery" className="px-4 py-2 text-base">Gallery</TabsTrigger>
               </TabsList>
             </div>


### PR DESCRIPTION
Rearrange Staff Profile tabs to Activities, Schedule, Commissions, Gallery and update 'Activity' label to 'Activities'.

---
<a href="https://cursor.com/background-agent?bcId=bc-43c64d9d-9419-4788-ae23-6f031bbe40a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-43c64d9d-9419-4788-ae23-6f031bbe40a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

