### PR TITLE
Replace schedule amount with service name

### DIFF
--- a/src/pages/StaffProfile.tsx
+++ b/src/pages/StaffProfile.tsx
@@ -140,7 +140,7 @@ export default function StaffProfile() {
       const [directRes, hasApptServices] = await Promise.all([
         supabase
           .from('appointments')
-          .select('id, appointment_date, appointment_time, status, price, staff_id')
+          .select('id, appointment_date, appointment_time, status, price, staff_id, service_name')
           .eq('staff_id', id)
           .gte('appointment_date', startDate)
           .lte('appointment_date', endDate),
@@ -159,7 +159,7 @@ export default function StaffProfile() {
         if (apptIds.length) {
           const { data: apptsByService } = await supabase
             .from('appointments')
-            .select('id, appointment_date, appointment_time, status, price')
+            .select('id, appointment_date, appointment_time, status, price, service_name')
             .in('id', apptIds)
             .gte('appointment_date', startDate)
             .lte('appointment_date', endDate);
@@ -560,7 +560,7 @@ export default function StaffProfile() {
                           <TableRow>
                             <TableHead>Date</TableHead>
                             <TableHead>Status</TableHead>
-                            <TableHead className="text-right">Amount</TableHead>
+                            <TableHead>Service</TableHead>
                           </TableRow>
                         </TableHeader>
                         <TableBody>
@@ -574,7 +574,7 @@ export default function StaffProfile() {
                                   </Badge>
                                 ) : '—'}
                               </TableCell>
-                              <TableCell className="text-right">{formatMoney(Number(a.price || 0))}</TableCell>
+                              <TableCell>{a.service_name || '—'}</TableCell>
                             </TableRow>
                           ))}
                         </TableBody>
@@ -610,7 +610,7 @@ export default function StaffProfile() {
                           <TableRow>
                             <TableHead>Time</TableHead>
                             <TableHead>Status</TableHead>
-                            <TableHead className="text-right">Amount</TableHead>
+                            <TableHead>Service</TableHead>
                           </TableRow>
                         </TableHeader>
                         <TableBody>
@@ -631,7 +631,7 @@ export default function StaffProfile() {
                                       </Badge>
                                     ) : '—'}
                                   </TableCell>
-                                  <TableCell className="text-right">{formatMoney(Number(a.price || 0))}</TableCell>
+                                  <TableCell>{a.service_name || '—'}</TableCell>
                                 </TableRow>
                               ))
                           )}


### PR DESCRIPTION
Replaces the 'Amount' column with 'Service' in the staff profile's schedule and activity appointment tables to show the service name instead of the price.

---
<a href="https://cursor.com/background-agent?bcId=bc-f9ccd5ec-b501-415c-b2a0-72691aaf4e14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f9ccd5ec-b501-415c-b2a0-72691aaf4e14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

