### PR TITLE
Handle dynamic import fetch errors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,8 +8,8 @@ import AppFooter from "@/components/layout/AppFooter";
 import DashboardLayout from "@/components/layout/DashboardLayout";
 
 // Auth Pages
-const Login = lazy(() => import("@/pages/Login"));
-const Register = lazy(() => import("@/pages/Register"));
+import Login from "@/pages/Login";
+import Register from "@/pages/Register";
 
 
 // Main Pages

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,24 @@ import { ThemeProvider } from 'next-themes'
 
 // Clear stale caches and force reload once if a dynamic import (chunk) fails
 if (typeof window !== 'undefined') {
+	const hardResetCachesAndSW = async () => {
+		try {
+			if ('serviceWorker' in navigator) {
+				const regs = await navigator.serviceWorker.getRegistrations();
+				await Promise.all(regs.map((r) => r.unregister()));
+			}
+		} catch {}
+		try {
+			if ('caches' in window) {
+				const cacheNames = await caches.keys();
+				await Promise.all(cacheNames.map((name) => caches.delete(name)));
+			}
+		} catch {}
+		try {
+			localStorage.removeItem('vite-plugin-pwa:register');
+		} catch {}
+	};
+
 	const maybeRecoverFromChunkError = async (reasonOrEvent: any) => {
 		const message = (reasonOrEvent?.message) || String(reasonOrEvent?.reason || reasonOrEvent?.error || reasonOrEvent);
 		const isChunkLoadError = message.includes('Failed to fetch dynamically imported module')
@@ -13,13 +31,7 @@ if (typeof window !== 'undefined') {
 		const didAttemptRecovery = sessionStorage.getItem('did-recover-from-chunk-error') === '1';
 		if (isChunkLoadError && !didAttemptRecovery) {
 			try {
-				if ('caches' in window) {
-					const cacheNames = await caches.keys();
-					await Promise.all(cacheNames.map((name) => caches.delete(name)));
-				}
-			} catch {}
-			try {
-				localStorage.removeItem('vite-plugin-pwa:register');
+				await hardResetCachesAndSW();
 			} catch {}
 			sessionStorage.setItem('did-recover-from-chunk-error', '1');
 			// Perform a cache-busting reload to avoid stale entry/chunk mismatches
@@ -30,6 +42,12 @@ if (typeof window !== 'undefined') {
 	};
 	window.addEventListener('error', (event) => { void maybeRecoverFromChunkError(event); }, { capture: true });
 	window.addEventListener('unhandledrejection', (event) => { void maybeRecoverFromChunkError(event); });
+
+	// Prefetch critical auth routes to reduce chances of lazy-load failures on first navigation
+	setTimeout(() => {
+		void import('@/pages/Login').catch(() => {});
+		void import('@/pages/Register').catch(() => {});
+	}, 0);
 }
 
 createRoot(document.getElementById("root")!).render(


### PR DESCRIPTION
Eager-load critical auth routes and add robust chunk error recovery to fix dynamic module fetch failures.

This addresses `TypeError: Failed to fetch dynamically imported module` errors, which often occur when a cached browser bundle references a non-existent chunk after a deployment. By eager-loading Login/Register pages, their dynamic import is eliminated. The enhanced recovery logic now unregisters service workers, clears all caches, and performs a cache-busting reload upon detecting a chunk load error, providing a more resilient self-healing mechanism.

---
<a href="https://cursor.com/background-agent?bcId=bc-938d5120-9396-4240-8260-eefb222aac27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-938d5120-9396-4240-8260-eefb222aac27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

