### PR TITLE
Handle dynamic import TypeError

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,8 +93,8 @@ importers:
         specifier: 1.2.7
         version: 1.2.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@supabase/supabase-js':
-        specifier: ^2.53.0
-        version: 2.54.0
+        specifier: ^2.55.0
+        version: 2.55.0
       '@tanstack/react-query':
         specifier: ^5.56.2
         version: 5.84.2(react@18.3.1)
@@ -125,6 +125,9 @@ importers:
       jspdf:
         specifier: ^3.0.1
         version: 3.0.1
+      lovable-tagger:
+        specifier: ^1.1.9
+        version: 1.1.9(vite@7.1.2(@types/node@22.17.1)(jiti@1.21.7)(yaml@2.8.1))
       lucide-react:
         specifier: ^0.462.0
         version: 0.462.0(react@18.3.1)
@@ -223,8 +226,25 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.27.1':
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.28.3':
+    resolution: {integrity: sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.28.2':
     resolution: {integrity: sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.28.2':
+    resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
     engines: {node: '>=6.9.0'}
 
   '@esbuild/aix-ppc64@0.25.8':
@@ -1239,14 +1259,14 @@ packages:
   '@supabase/postgrest-js@1.19.4':
     resolution: {integrity: sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==}
 
-  '@supabase/realtime-js@2.15.0':
-    resolution: {integrity: sha512-SEIWApsxyoAe68WU2/5PCCuBwa11LL4Bb8K3r2FHCt3ROpaTthmDiWEhnLMGayP05N4QeYrMk0kyTZOwid/Hjw==}
+  '@supabase/realtime-js@2.15.1':
+    resolution: {integrity: sha512-edRFa2IrQw50kNntvUyS38hsL7t2d/psah6om6aNTLLcWem0R6bOUq7sk7DsGeSlNfuwEwWn57FdYSva6VddYw==}
 
   '@supabase/storage-js@2.10.4':
     resolution: {integrity: sha512-cvL02GarJVFcNoWe36VBybQqTVRq6wQSOCvTS64C+eyuxOruFIm1utZAY0xi2qKtHJO3EjKaj8iWJKySusDmAQ==}
 
-  '@supabase/supabase-js@2.54.0':
-    resolution: {integrity: sha512-DLw83YwBfAaFiL3oWV26+sHRdeCGtxmIKccjh/Pndze3BWM4fZghzYKhk3ElOQU8Bluq4AkkCJ5bM5Szl/sfRg==}
+  '@supabase/supabase-js@2.55.0':
+    resolution: {integrity: sha512-Y1uV4nEMjQV1x83DGn7+Z9LOisVVRlY1geSARrUHbXWgbyKLZ6/08dvc0Us1r6AJ4tcKpwpCZWG9yDQYo1JgHg==}
 
   '@swc/core-darwin-arm64@1.13.3':
     resolution: {integrity: sha512-ux0Ws4pSpBTqbDS9GlVP354MekB1DwYlbxXU3VhnDr4GBcCOimpocx62x7cFJkSpEBF8bmX8+/TTCGKh4PbyXw==}
@@ -1784,6 +1804,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2008,6 +2031,11 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lovable-tagger@1.1.9:
+    resolution: {integrity: sha512-Y1KyTYKu9H8RTiRTmKnbQvlO5qEEgsszCiMDSh1onTAdgSuLZRFdiuRxj8JN2zQNt/nMoi6R2414JfstM/s1ig==}
+    peerDependencies:
+      vite: ^5.0.0
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -2015,6 +2043,9 @@ packages:
     resolution: {integrity: sha512-NTL7EbAao9IFtuSivSZgrAh4fZd09Lr+6MTkqIxuHaH2nnYiYIzXPo06cOxHg9wKLdj6LL8TByG4qpePqwgx/g==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
+
+  magic-string@0.30.17:
+    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -2604,7 +2635,20 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.27.1': {}
+
+  '@babel/parser@7.28.3':
+    dependencies:
+      '@babel/types': 7.28.2
+
   '@babel/runtime@7.28.2': {}
+
+  '@babel/types@7.28.2':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
 
   '@esbuild/aix-ppc64@0.25.8':
     optional: true
@@ -3553,7 +3597,7 @@ snapshots:
     dependencies:
       '@supabase/node-fetch': 2.6.15
 
-  '@supabase/realtime-js@2.15.0':
+  '@supabase/realtime-js@2.15.1':
     dependencies:
       '@supabase/node-fetch': 2.6.15
       '@types/phoenix': 1.6.6
@@ -3567,13 +3611,13 @@ snapshots:
     dependencies:
       '@supabase/node-fetch': 2.6.15
 
-  '@supabase/supabase-js@2.54.0':
+  '@supabase/supabase-js@2.55.0':
     dependencies:
       '@supabase/auth-js': 2.71.1
       '@supabase/functions-js': 2.4.5
       '@supabase/node-fetch': 2.6.15
       '@supabase/postgrest-js': 1.19.4
-      '@supabase/realtime-js': 2.15.0
+      '@supabase/realtime-js': 2.15.1
       '@supabase/storage-js': 2.10.4
     transitivePeerDependencies:
       - bufferutil
@@ -4154,6 +4198,10 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   eventemitter3@4.0.7: {}
@@ -4351,11 +4399,27 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lovable-tagger@1.1.9(vite@7.1.2(@types/node@22.17.1)(jiti@1.21.7)(yaml@2.8.1)):
+    dependencies:
+      '@babel/parser': 7.28.3
+      '@babel/types': 7.28.2
+      esbuild: 0.25.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+      tailwindcss: 3.4.17
+      vite: 7.1.2(@types/node@22.17.1)(jiti@1.21.7)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - ts-node
+
   lru-cache@10.4.3: {}
 
   lucide-react@0.462.0(react@18.3.1):
     dependencies:
       react: 18.3.1
+
+  magic-string@0.30.17:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.4
 
   merge2@1.4.1: {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 
 import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-dom";
 import { useSaas } from "@/lib/saas";
-import React, { Suspense, lazy } from "react";
+import React, { Suspense, lazy, useEffect } from "react";
 import { Toaster } from "@/components/ui/sonner";
 import AppFooter from "@/components/layout/AppFooter";
 
@@ -79,6 +79,19 @@ const AppRoutes = () => {
       </Suspense>
     );
   }
+
+  // Prefetch some commonly used lazy routes soon after auth/org is ready
+  useEffect(() => {
+    if (user && organization?.id) {
+      setTimeout(() => {
+        void Promise.all([
+          import('@/pages/Accounts').catch(() => {}),
+          import('@/pages/Invoices').catch(() => {}),
+          import('@/pages/Payments').catch(() => {}),
+        ]);
+      }, 0);
+    }
+  }, [user, organization?.id]);
 
   // Super admin routes
   if (isSuperAdmin && window.location.pathname.startsWith('/admin')) {

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -2,6 +2,7 @@ import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { isChunkError, recoverFromChunkErrorOnce } from '@/utils/chunkRecovery';
 
 interface Props {
   children: ReactNode;
@@ -23,9 +24,12 @@ export class ErrorBoundary extends Component<Props, State> {
     return { hasError: true, error, errorInfo: null };
   }
 
-  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+  async componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.error('ErrorBoundary caught an error:', error, errorInfo);
     this.setState({ error, errorInfo });
+    if (isChunkError(error)) {
+      await recoverFromChunkErrorOnce();
+    }
   }
 
   render() {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,45 +4,11 @@ import App from './App.tsx'
 import './index.css'
 import { SaasProvider } from '@/lib/saas'
 import { ThemeProvider } from 'next-themes'
+import { registerGlobalChunkErrorHandlers } from '@/utils/chunkRecovery'
 
 // Clear stale caches and force reload once if a dynamic import (chunk) fails
 if (typeof window !== 'undefined') {
-	const hardResetCachesAndSW = async () => {
-		try {
-			if ('serviceWorker' in navigator) {
-				const regs = await navigator.serviceWorker.getRegistrations();
-				await Promise.all(regs.map((r) => r.unregister()));
-			}
-		} catch {}
-		try {
-			if ('caches' in window) {
-				const cacheNames = await caches.keys();
-				await Promise.all(cacheNames.map((name) => caches.delete(name)));
-			}
-		} catch {}
-		try {
-			localStorage.removeItem('vite-plugin-pwa:register');
-		} catch {}
-	};
-
-	const maybeRecoverFromChunkError = async (reasonOrEvent: any) => {
-		const message = (reasonOrEvent?.message) || String(reasonOrEvent?.reason || reasonOrEvent?.error || reasonOrEvent);
-		const isChunkLoadError = message.includes('Failed to fetch dynamically imported module')
-			|| message.includes('ChunkLoadError');
-		const didAttemptRecovery = sessionStorage.getItem('did-recover-from-chunk-error') === '1';
-		if (isChunkLoadError && !didAttemptRecovery) {
-			try {
-				await hardResetCachesAndSW();
-			} catch {}
-			sessionStorage.setItem('did-recover-from-chunk-error', '1');
-			// Perform a cache-busting reload to avoid stale entry/chunk mismatches
-			const url = new URL(window.location.href);
-			url.searchParams.set('v', String(Date.now()));
-			window.location.replace(url.toString());
-		}
-	};
-	window.addEventListener('error', (event) => { void maybeRecoverFromChunkError(event); }, { capture: true });
-	window.addEventListener('unhandledrejection', (event) => { void maybeRecoverFromChunkError(event); });
+	registerGlobalChunkErrorHandlers();
 
 	// Prefetch critical auth routes to reduce chances of lazy-load failures on first navigation
 	setTimeout(() => {

--- a/src/utils/chunkRecovery.ts
+++ b/src/utils/chunkRecovery.ts
@@ -1,0 +1,71 @@
+export const CHUNK_ERROR_FLAG_KEY = 'did-recover-from-chunk-error';
+
+export function isChunkError(reasonOrEvent: any): boolean {
+  try {
+    const message = String(
+      reasonOrEvent?.message ||
+      reasonOrEvent?.reason?.message ||
+      reasonOrEvent?.error?.message ||
+      reasonOrEvent?.reason ||
+      reasonOrEvent?.error ||
+      reasonOrEvent
+    );
+    return message.includes('Failed to fetch dynamically imported module') ||
+      message.includes('ChunkLoadError') ||
+      message.includes('Loading chunk') && message.includes('failed');
+  } catch {
+    return false;
+  }
+}
+
+export async function hardResetCachesAndServiceWorkers(): Promise<void> {
+  try {
+    if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
+      const regs = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(regs.map((r) => r.unregister()));
+    }
+  } catch {}
+  try {
+    if (typeof caches !== 'undefined') {
+      const cacheNames = await caches.keys();
+      await Promise.all(cacheNames.map((name) => caches.delete(name)));
+    }
+  } catch {}
+  try {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.removeItem('vite-plugin-pwa:register');
+    }
+  } catch {}
+}
+
+export async function recoverFromChunkErrorOnce(): Promise<void> {
+  try {
+    if (typeof window === 'undefined') return;
+    const didAttemptRecovery = sessionStorage.getItem(CHUNK_ERROR_FLAG_KEY) === '1';
+    if (didAttemptRecovery) return;
+
+    await hardResetCachesAndServiceWorkers();
+    sessionStorage.setItem(CHUNK_ERROR_FLAG_KEY, '1');
+
+    const url = new URL(window.location.href);
+    url.searchParams.set('v', String(Date.now()));
+    window.location.replace(url.toString());
+  } catch {
+    // As a last resort, try a normal reload
+    try { window.location.reload(); } catch {}
+  }
+}
+
+export function registerGlobalChunkErrorHandlers(): void {
+  if (typeof window === 'undefined') return;
+
+  const handler = (evt: any) => {
+    const payload = (evt && ('reason' in evt || 'error' in evt)) ? (evt.reason || evt.error) : evt;
+    if (isChunkError(payload)) {
+      void recoverFromChunkErrorOnce();
+    }
+  };
+
+  window.addEventListener('error', handler as any, { capture: true });
+  window.addEventListener('unhandledrejection', handler as any);
+}


### PR DESCRIPTION
Implement robust chunk error recovery and prefetching to resolve dynamic module fetch failures.

The `TypeError: Failed to fetch dynamically imported module` typically arises from stale client-side caches (e.g., old `index.html` or service worker) referencing JavaScript chunks that have been renamed or removed in a new deployment. This PR centralizes chunk error handling to clear caches and force a reload, and pre-fetches key lazy routes to minimize these occurrences.

---
<a href="https://cursor.com/background-agent?bcId=bc-e8f35b8a-5b5c-4965-8162-56a39e749ae5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e8f35b8a-5b5c-4965-8162-56a39e749ae5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

