### PR TITLE
Debug dynamic import fetch errors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -217,9 +217,17 @@ const AppRoutes = () => {
 };
 
 function App() {
+  // Derive Router basename from Vite's BASE_URL; if it's a full URL, use only the pathname.
+  const rawBase = (import.meta.env.BASE_URL as string) || '/';
+  let basePath = rawBase;
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(rawBase)) {
+    try { basePath = new URL(rawBase).pathname || '/'; } catch { basePath = '/'; }
+  }
+  const basename = basePath.replace(/\/+$/, '') || '/';
+
   return (
     <ErrorBoundary>
-      <Router basename={import.meta.env.BASE_URL}>
+      <Router basename={basename}>
         <AppRoutes />
         <Toaster />
         <AppFooter />

--- a/src/components/layout/SuperAdminLayout.tsx
+++ b/src/components/layout/SuperAdminLayout.tsx
@@ -5,6 +5,7 @@ import { SuperAdminTopbar } from "./Topbar";
 import { useSaas } from "@/lib/saas";
 import { supabase } from "@/integrations/supabase/client";
 import { useNavigate } from "react-router-dom";
+import { cleanupAuthState } from "@/utils/authUtils";
 
 interface SuperAdminLayoutProps {
   children?: React.ReactNode;
@@ -16,13 +17,18 @@ export default function SuperAdminLayout({ children }: SuperAdminLayoutProps = {
 
   const handleSignOut = async () => {
     try {
-      const { cleanupAuthState } = await import('@/utils/authUtils');
       cleanupAuthState();
       try {
         await supabase.auth.signOut({ scope: 'global' } as any);
       } catch (err) { /* ignore sign-out errors */ }
     } finally {
-      window.location.href = '/login';
+      const rawBase = (import.meta.env.BASE_URL as string) || '/';
+      let basePath = rawBase;
+      if (/^[a-z][a-z0-9+.-]*:\/\//i.test(rawBase)) {
+        try { basePath = new URL(rawBase).pathname || '/'; } catch { basePath = '/'; }
+      }
+      const prefix = basePath.replace(/\/+$/, '') || '/';
+      window.location.href = `${prefix}/login`;
     }
   };
 

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -15,6 +15,7 @@ import { useSaas } from "@/lib/saas";
 import { supabase } from "@/integrations/supabase/client";
 import { useNavigate } from "react-router-dom";
 import ThemeToggle from "@/components/ThemeToggle";
+import { cleanupAuthState } from "@/utils/authUtils";
 
 export function AppTopbar() {
   const navigate = useNavigate();
@@ -231,13 +232,18 @@ export function SuperAdminTopbar() {
 
   const handleSignOut = async () => {
     try {
-      const { cleanupAuthState } = await import('@/utils/authUtils');
       cleanupAuthState();
       try {
         await supabase.auth.signOut({ scope: 'global' } as any);
       } catch (err) { /* ignore sign-out errors */ }
     } finally {
-      window.location.href = '/login';
+      const rawBase = (import.meta.env.BASE_URL as string) || '/';
+      let basePath = rawBase;
+      if (/^[a-z][a-z0-9+.-]*:\/\//i.test(rawBase)) {
+        try { basePath = new URL(rawBase).pathname || '/'; } catch { basePath = '/'; }
+      }
+      const prefix = basePath.replace(/\/+$/, '') || '/';
+      window.location.href = `${prefix}/login`;
     }
   };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,8 +14,22 @@ export default defineConfig(async ({ mode }) => {
 		}
 	}
 
+	// Normalize base to avoid 404s for dynamically imported chunks when deploying under a subpath
+	const rawBase = process.env.VITE_BASE;
+	const base = (() => {
+		if (!rawBase) return "/";
+		// If full URL, ensure it ends with a slash
+		if (/^[a-z][a-z0-9+.-]*:\/\//i.test(rawBase)) {
+			return rawBase.endsWith('/') ? rawBase : `${rawBase}/`;
+		}
+		let b = rawBase;
+		if (!b.startsWith('/')) b = `/${b}`;
+		if (!b.endsWith('/')) b = `${b}/`;
+		return b;
+	})();
+
 	return {
-		base: process.env.VITE_BASE || "/",
+		base,
 		server: {
 			host: "::",
 			port: 8080,


### PR DESCRIPTION
Normalize Vite base and React Router basename to fix dynamic import failures and redirects under subpaths.

The "TypeError: Failed to fetch dynamically imported module" typically occurs when the browser tries to load a JavaScript chunk (generated by dynamic imports) from an incorrect URL. This PR ensures that Vite's build output and React Router's client-side navigation consistently use the correct base path, preventing 404s for these chunks, especially when the application is deployed to a URL subpath (e.g., `example.com/my-app/`). Additionally, critical utility imports were made static to reduce points of failure during sign-out.

---
<a href="https://cursor.com/background-agent?bcId=bc-896c4156-863c-43f6-baef-3b110e282ab3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-896c4156-863c-43f6-baef-3b110e282ab3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

