### PR TITLE
Handle authentication service connection failure

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -43,13 +43,6 @@ const Login = () => {
       // Clean up any existing auth state first
       cleanupAuthState();
       
-      // Test Supabase connection first
-      const { error: connectionError } = await supabase.from('profiles').select('count', { count: 'exact', head: true });
-      if (connectionError) {
-        console.error('Supabase connection failed:', connectionError);
-        throw new Error('Unable to connect to authentication service. Please try again later.');
-      }
-      
       // Attempt to sign out any existing session
       try {
         await supabase.auth.signOut({ scope: 'global' });


### PR DESCRIPTION
Remove pre-login Supabase connection test to prevent false 'Unable to connect' errors caused by RLS.

The previous connection test queried the `profiles` table, which could be blocked by Row Level Security (RLS), leading to a generic "Unable to connect to authentication service" error even if the Supabase service was operational. This change ensures that authentication errors are precise and come directly from the `signInWithPassword` attempt.

---
<a href="https://cursor.com/background-agent?bcId=bc-360c48d6-b8ff-48ef-95de-e3b3e968efcb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-360c48d6-b8ff-48ef-95de-e3b3e968efcb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

