### PR TITLE
Halve top padding on all pages

### DIFF
--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -90,7 +90,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps = {})
           <AppTopbar />
 
           {/* Main Content */}
-          <main id="main-content" className="flex-1 min-w-0 p-4 md:p-6 lg:p-8">
+          <main id="main-content" className="flex-1 min-w-0 px-4 md:px-6 lg:px-8 pb-4 md:pb-6 lg:pb-8 pt-2 md:pt-3 lg:pt-4">
             <React.Suspense fallback={
               <div className="flex items-center justify-center min-h-[400px]" role="status" aria-live="polite" aria-busy="true">
                 <div className="text-center space-y-4">

--- a/src/components/layout/SuperAdminLayout.tsx
+++ b/src/components/layout/SuperAdminLayout.tsx
@@ -43,7 +43,7 @@ export default function SuperAdminLayout({ children }: SuperAdminLayoutProps = {
           <SuperAdminTopbar />
 
           {/* Main Content */}
-          <main id="main-content" className="flex-1 bg-slate-50 p-4 md:p-6 lg:p-8 min-w-0">
+          <main id="main-content" className="flex-1 bg-slate-50 min-w-0 px-4 md:px-6 lg:px-8 pb-4 md:pb-6 lg:pb-8 pt-2 md:pt-3 lg:pt-4">
             {children || <Outlet />}
           </main>
         </div>

--- a/src/pages/ClientProfile.tsx
+++ b/src/pages/ClientProfile.tsx
@@ -282,7 +282,7 @@ export default function ClientProfile() {
   }
 
   return (
-      <div className="flex-1 space-y-6 p-8 pt-6">
+      <div className="flex-1 space-y-6 p-8 pt-3">
         {/* Client Header */}
         <Card className="mb-6">
           <CardContent className="pt-6">

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -702,7 +702,7 @@ phone: "",
   }
 
   return (
-    <div className="flex-1 space-y-6 p-8 pt-6">
+    <div className="flex-1 space-y-6 p-8 pt-3">
       {/* Header */}
       <div>
         <h1 className="text-3xl font-bold tracking-tight bg-gradient-to-r from-pink-600 to-purple-600 bg-clip-text text-transparent">

--- a/src/pages/StockTransfers.tsx
+++ b/src/pages/StockTransfers.tsx
@@ -356,7 +356,7 @@ export default function StockTransfers() {
   };
 
   return (
-    <div className="flex-1 space-y-6 p-8 pt-6">
+    <div className="flex-1 space-y-6 p-8 pt-3">
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-3xl font-bold tracking-tight">Stock Transfers</h2>

--- a/src/pages/SupplierProfile.tsx
+++ b/src/pages/SupplierProfile.tsx
@@ -200,7 +200,7 @@ export default function SupplierProfile() {
   }
 
   return (
-    <div className="flex-1 space-y-6 p-8 pt-6">
+    <div className="flex-1 space-y-6 p-8 pt-3">
       {/* Header */}
       <Card className="mb-6">
         <CardContent className="pt-6">


### PR DESCRIPTION
Halve the top padding across the entire application by adjusting layout components and specific page wrappers.

---
<a href="https://cursor.com/background-agent?bcId=bc-d46e2033-2f0e-43fb-bea4-a1b6eaf1cd1b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d46e2033-2f0e-43fb-bea4-a1b6eaf1cd1b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

