### PR TITLE
Reduce padding on most pages

### DIFF
--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -90,7 +90,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps = {})
           <AppTopbar />
 
           {/* Main Content */}
-          <main id="main-content" className="flex-1 min-w-0 px-4 md:px-6 lg:px-8 pb-4 md:pb-6 lg:pb-8 pt-2 md:pt-3 lg:pt-4">
+          <main id="main-content" className="flex-1 min-w-0 px-1 md:px-1.5 lg:px-2 pb-1 md:pb-1.5 lg:pb-2 pt-0.5 md:pt-[3px] lg:pt-1">
             <React.Suspense fallback={
               <div className="flex items-center justify-center min-h-[400px]" role="status" aria-live="polite" aria-busy="true">
                 <div className="text-center space-y-4">

--- a/src/components/layout/SuperAdminLayout.tsx
+++ b/src/components/layout/SuperAdminLayout.tsx
@@ -43,7 +43,7 @@ export default function SuperAdminLayout({ children }: SuperAdminLayoutProps = {
           <SuperAdminTopbar />
 
           {/* Main Content */}
-          <main id="main-content" className="flex-1 bg-slate-50 min-w-0 px-4 md:px-6 lg:px-8 pb-4 md:pb-6 lg:pb-8 pt-2 md:pt-3 lg:pt-4">
+          <main id="main-content" className="flex-1 bg-slate-50 min-w-0 px-1 md:px-1.5 lg:px-2 pb-1 md:pb-1.5 lg:pb-2 pt-0.5 md:pt-[3px] lg:pt-1">
             {children || <Outlet />}
           </main>
         </div>


### PR DESCRIPTION
Reduce page padding by 75% in all pages except Landing, Login, and Signup.

---
<a href="https://cursor.com/background-agent?bcId=bc-13be35fb-bbe9-4828-b613-0d24bb8c6dae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-13be35fb-bbe9-4828-b613-0d24bb8c6dae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

