### PR TITLE
Enlarge kit item tabs for multi-service job cards

### DIFF
--- a/src/pages/CreateJobCard.tsx
+++ b/src/pages/CreateJobCard.tsx
@@ -1432,9 +1432,9 @@ function StepProductsMaterials({
           <CardContent className="p-6">
             {showTabs ? (
               <Tabs defaultValue={defaultTab} className="space-y-6">
-                <TabsList>
+                <TabsList className="h-12 gap-2 p-2">
                   {servicesWithKits.map((svc) => (
-                    <TabsTrigger key={svc.id} value={svc.id}>{svc.name}</TabsTrigger>
+                    <TabsTrigger key={svc.id} value={svc.id} className="px-6 py-3 text-base md:text-lg">{svc.name}</TabsTrigger>
                   ))}
                 </TabsList>
                 {servicesWithKits.map((svc) => {


### PR DESCRIPTION
Enlarge kit item tabs on the Create Job Card for job cards with multiple services to improve visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f270c29-49b9-42ed-833e-c7106087070c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2f270c29-49b9-42ed-833e-c7106087070c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

