### PR TITLE
Fix missing export in saas utils

### DIFF
--- a/src/lib/saas/index.ts
+++ b/src/lib/saas/index.ts
@@ -55,54 +55,10 @@ export type {
 } from './types'
 
 // Services
-export {
-  OrganizationService,
-  SubscriptionService,
-  UserService,
-  SuperAdminService,
-  UsageService,
-  AnalyticsService,
-  CacheService,
-} from './services'
+export * from './services'
 
 // Utilities
-export {
-  hasMinimumRole,
-  canPerformAction,
-  getRolePermissions,
-  isRoleHigherThan,
-  isSubscriptionActive,
-  isSubscriptionTrialing,
-  calculateTrialDaysRemaining,
-  formatSubscriptionStatus,
-  calculateFeatureAccess,
-  isApproachingUsageLimit,
-  isAtUsageLimit,
-  getUsagePercentage,
-  shouldShowUsageWarning,
-  createSlugFromName,
-  generateUniqueSlug,
-  formatRelativeTime,
-  isDateInFuture,
-  isDateInPast,
-  createSaasError,
-  isSaasError,
-  getErrorMessage,
-  validateEmail,
-  validateOrganizationName,
-  validateSlug,
-  sanitizeOrganizationData,
-  formatCurrency,
-  formatNumber,
-  createCacheKey,
-  isExpired,
-  checkFeatureFlag,
-  getFeatureValue,
-  groupBy,
-  sortBy,
-  omit,
-  pick,
-} from './utils'
+export * from './utils'
 
 // Constants
 export {


### PR DESCRIPTION
Change named re-exports to wildcard re-exports in `src/lib/saas/index.ts` to resolve a `SyntaxError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-5578f774-83ab-4ae0-a555-fe3d74a46073">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5578f774-83ab-4ae0-a555-fe3d74a46073">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

