### PR TITLE
Fix formatUsdCents function error

### DIFF
--- a/src/lib/saas/hooks.ts
+++ b/src/lib/saas/hooks.ts
@@ -101,7 +101,7 @@ export function useOrganizationCurrency() {
   }
   
   // Get currency from organization or use default
-  const currency = context.organization?.currency || { code: 'USD', symbol: '$' };
+  const currency = ((context.organization as any)?.currency) || { code: 'USD', symbol: '$' };
   
   const formatCurrency = (amount: number, options?: { 
     showSymbol?: boolean; 
@@ -121,11 +121,20 @@ export function useOrganizationCurrency() {
     
     return showSymbol ? `${currency.symbol}${formattedAmount}` : formattedAmount;
   };
+
+  // Backward-compat helpers
+  const format = formatCurrency;
+  const symbol = currency.symbol;
+  const formatUsdCents = (cents: number) => formatCurrency((cents || 0) / 100);
   
   return {
     currency,
     formatCurrency,
     currencyCode: currency.code,
-    currencySymbol: currency.symbol
+    currencySymbol: currency.symbol,
+    // Backward-compat fields expected by existing code
+    format,
+    symbol,
+    formatUsdCents,
   };
 }


### PR DESCRIPTION
Expose `formatUsdCents`, `format`, and `symbol` from `useOrganizationCurrency` to resolve `TypeError: formatUsdCents is not a function`.

---
<a href="https://cursor.com/background-agent?bcId=bc-c3b7b43c-c415-444c-8d24-078f06f31fae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c3b7b43c-c415-444c-8d24-078f06f31fae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

