### PR TITLE
Fix super admin page not found error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,6 +71,15 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 // Admin pages
 const AdminDashboard = lazy(() => import("@/pages/admin/AdminDashboard"));
+const AdminOrganizations = lazy(() => import("@/pages/admin/AdminOrganizations"));
+const AdminUsers = lazy(() => import("@/pages/admin/AdminUsers"));
+const AdminInvitations = lazy(() => import("@/pages/admin/AdminInvitations"));
+const AdminSubscriptionPlans = lazy(() => import("@/pages/admin/AdminSubscriptionPlans"));
+const AdminSystemSettings = lazy(() => import("@/pages/admin/AdminSystemSettings"));
+const AdminBusinessData = lazy(() => import("@/pages/admin/AdminBusinessData"));
+const AdminActivity = lazy(() => import("@/pages/admin/AdminActivity"));
+const AdminLandingCMS = lazy(() => import("@/pages/admin/AdminLandingCMS"));
+const AdminSuperAdmins = lazy(() => import("@/pages/admin/AdminSuperAdmins"));
 
 // Loading component
 const LoadingFallback = () => (
@@ -120,12 +129,28 @@ const AppRoutes = () => {
   }, [user, organization?.id]);
 
   // Super admin routes
-  if (isSuperAdmin && window.location.pathname.startsWith('/admin')) {
+  if (isSuperAdmin && (window.location.pathname.startsWith('/admin') || window.location.pathname.startsWith('/super-admin'))) {
     return (
       <Suspense fallback={<LoadingFallback />}>
         <Routes>
+          {/* canonical admin dashboard */}
           <Route path="/admin" element={<AdminDashboard />} />
-          <Route path="/admin/*" element={<AdminDashboard />} />
+          <Route path="/admin/dashboard" element={<AdminDashboard />} />
+          {/* admin pages */}
+          <Route path="/admin/organizations" element={<AdminOrganizations />} />
+          <Route path="/admin/subscription-plans" element={<AdminSubscriptionPlans />} />
+          <Route path="/admin/users" element={<AdminUsers />} />
+          <Route path="/admin/invitations" element={<AdminInvitations />} />
+          <Route path="/admin/super-admins" element={<AdminSuperAdmins />} />
+          <Route path="/admin/activity" element={<AdminActivity />} />
+          <Route path="/admin/system-settings" element={<AdminSystemSettings />} />
+          <Route path="/admin/business-data" element={<AdminBusinessData />} />
+          <Route path="/admin/cms" element={<AdminLandingCMS />} />
+          {/* legacy path redirects */}
+          <Route path="/super-admin" element={<Navigate to="/admin" replace />} />
+          <Route path="/super-admin/*" element={<Navigate to="/admin" replace />} />
+          {/* fallback */}
+          <Route path="/admin/*" element={<Navigate to="/admin" replace />} />
           <Route path="*" element={<Navigate to="/admin" replace />} />
         </Routes>
       </Suspense>

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -253,7 +253,7 @@ const menuItems: MenuItem[] = [
 // Super Admin menu item (separate from main menu since it's system-wide)
 const superAdminMenuItem: MenuItem = {
   title: "Super Admin",
-  url: "/super-admin",
+  url: "/admin",
   icon: Crown,
   feature: "system", // This will always be false for regular features, we'll handle it separately
 };
@@ -512,12 +512,12 @@ export function AppSidebar() {
                 <SidebarMenuItem>
                   <SidebarMenuButton
                     asChild
-                    isActive={location.pathname === '/super-admin/cms'}
+                    isActive={location.pathname === '/admin/cms'}
                     className="hover:bg-violet-50 data-[active=true]:bg-violet-100 data-[active=true]:text-violet-900 text-base"
                     tooltip={state === 'collapsed' ? 'Landing CMS' : undefined}
                     size="lg"
                   >
-                    <NavLink to="/super-admin/cms" className={({ isActive }) => `flex items-center gap-2 ${isActive ? 'bg-accent text-accent-foreground' : ''}`} onClick={handleNavClick}>
+                    <NavLink to="/admin/cms" className={({ isActive }) => `flex items-center gap-2 ${isActive ? 'bg-accent text-accent-foreground' : ''}`} onClick={handleNavClick}>
                       <Sparkles className={`h-5 w-5 ${getIconColorForTitle('Landing CMS')}`} />
                       <span>Landing CMS</span>
                     </NavLink>

--- a/src/components/layout/SuperAdminSidebar.tsx
+++ b/src/components/layout/SuperAdminSidebar.tsx
@@ -45,7 +45,7 @@ interface SuperAdminMenuItem {
 const superAdminMenuItems: SuperAdminMenuItem[] = [
   {
     title: "Overview",
-    url: "/super-admin",
+    url: "/admin",
     icon: BarChart3,
   },
   {
@@ -85,7 +85,7 @@ const superAdminMenuItems: SuperAdminMenuItem[] = [
       },
       {
         title: "Super Admins",
-        url: "/admin/users",
+        url: "/admin/super-admins",
         icon: Shield,
       },
     ],
@@ -96,7 +96,7 @@ const superAdminMenuItems: SuperAdminMenuItem[] = [
     subItems: [
       {
         title: "Landing CMS",
-        url: "/super-admin/cms",
+        url: "/admin/cms",
         icon: FileText,
       },
     ],
@@ -112,7 +112,7 @@ const superAdminMenuItems: SuperAdminMenuItem[] = [
       },
       {
         title: "Activity Logs",
-        url: "/super-admin/activity",
+        url: "/admin/activity",
         icon: Activity,
       },
     ],
@@ -123,7 +123,7 @@ const superAdminMenuItems: SuperAdminMenuItem[] = [
     subItems: [
       {
         title: "System Settings",
-        url: "/super-admin/settings",
+        url: "/admin/system-settings",
         icon: Settings,
       },
     ],
@@ -271,19 +271,19 @@ export function SuperAdminSidebar() {
           <SidebarGroupContent>
             <div className="px-2 py-3 space-y-2">
               <NavLink
-                to="/super-admin"
+                to="/admin"
                 className="block w-full text-left p-2 rounded-md bg-purple-100 hover:bg-purple-200 text-purple-800 text-sm font-medium transition-colors"
               >
                 Create Organization
               </NavLink>
               <NavLink
-                to="/super-admin"
+                to="/admin"
                 className="block w-full text-left p-2 rounded-md bg-purple-100 hover:bg-purple-200 text-purple-800 text-sm font-medium transition-colors"
               >
                 Grant Super Admin
               </NavLink>
               <NavLink
-                to="/super-admin/activity"
+                to="/admin/activity"
                 className="block w-full text-left p-2 rounded-md bg-purple-100 hover:bg-purple-200 text-purple-800 text-sm font-medium transition-colors"
               >
                 View Activity Log


### PR DESCRIPTION
Aligns super admin routing and navigation to use `/admin` paths and adds redirects from legacy `/super-admin` paths to resolve "page not found" issues.

The system previously had a mix of `/admin` and `/super-admin` paths for the super admin section. This led to "page not found" errors when users tried to access pages via `/super-admin` links, as the router was primarily configured for `/admin`. This PR standardizes all super admin routes under `/admin` and ensures old links redirect correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-74d1aaa2-6fed-48e7-89e8-a20b51cfe8aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-74d1aaa2-6fed-48e7-89e8-a20b51cfe8aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

