### PR TITLE
Rebuild super admin functionality

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,7 +84,16 @@ import BusinessDirectory from "@/pages/BusinessDirectory";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 // Admin pages
-
+const AdminDashboard = lazyWithRetry(() => import("@/pages/admin/AdminDashboard"));
+const AdminOrganizations = lazyWithRetry(() => import("@/pages/admin/AdminOrganizations"));
+const AdminSubscriptionPlans = lazyWithRetry(() => import("@/pages/admin/AdminSubscriptionPlans"));
+const AdminUsers = lazyWithRetry(() => import("@/pages/admin/AdminUsers"));
+const AdminInvitations = lazyWithRetry(() => import("@/pages/admin/AdminInvitations"));
+const AdminSuperAdmins = lazyWithRetry(() => import("@/pages/admin/AdminSuperAdmins"));
+const AdminActivity = lazyWithRetry(() => import("@/pages/admin/AdminActivity"));
+const AdminSystemSettings = lazyWithRetry(() => import("@/pages/admin/AdminSystemSettings"));
+const AdminBusinessData = lazyWithRetry(() => import("@/pages/admin/AdminBusinessData"));
+const AdminLandingCMS = lazyWithRetry(() => import("@/pages/admin/AdminLandingCMS"));
 
 // Loading component
 const LoadingFallback = () => (

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2535,6 +2535,7 @@ export type Database = {
           is_active: boolean | null
           updated_at: string
           user_id: string
+          permissions: Json | null
         }
         Insert: {
           created_at?: string
@@ -2544,6 +2545,7 @@ export type Database = {
           is_active?: boolean | null
           updated_at?: string
           user_id: string
+          permissions?: Json | null
         }
         Update: {
           created_at?: string
@@ -2553,6 +2555,7 @@ export type Database = {
           is_active?: boolean | null
           updated_at?: string
           user_id?: string
+          permissions?: Json | null
         }
         Relationships: []
       }


### PR DESCRIPTION
Enable Super admin functionality by adding lazy imports for admin pages and updating the `super_admins` type definition.

---
<a href="https://cursor.com/background-agent?bcId=bc-c1155830-a7d2-4f2e-b234-501ee050cdbc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c1155830-a7d2-4f2e-b234-501ee050cdbc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

