### PR TITLE
Fix undefined AdminDashboard reference

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -85,7 +85,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import RequirePermission from "@/components/auth/RequirePermission";
 
 // Admin pages
-const AdminDashboard = lazyWithRetry(() => import("@/pages/admin/AdminDashboard"));
+const AdminDashboardPage = lazyWithRetry(() => import("@/pages/admin/AdminDashboard"));
 const AdminOrganizations = lazyWithRetry(() => import("@/pages/admin/AdminOrganizations"));
 const AdminSubscriptionPlans = lazyWithRetry(() => import("@/pages/admin/AdminSubscriptionPlans"));
 const AdminUsers = lazyWithRetry(() => import("@/pages/admin/AdminUsers"));
@@ -149,8 +149,8 @@ const AppRoutes = () => {
       <Suspense fallback={<LoadingFallback />}>
         <Routes>
           {/* canonical admin dashboard */}
-          <Route path="/admin" element={<AdminDashboard />} />
-          <Route path="/admin/dashboard" element={<AdminDashboard />} />
+          <Route path="/admin" element={<AdminDashboardPage />} />
+          <Route path="/admin/dashboard" element={<AdminDashboardPage />} />
           {/* admin pages */}
           <Route path="/admin/organizations" element={<AdminOrganizations />} />
           <Route path="/admin/subscription-plans" element={<AdminSubscriptionPlans />} />


### PR DESCRIPTION
Rename lazy-loaded `AdminDashboard` component variable to `AdminDashboardPage` to resolve a `ReferenceError`.

The `ReferenceError: AdminDashboard is not defined` occurred at runtime, likely due to a naming collision with another variable or scope expecting `AdminDashboard`. Renaming the lazy-loaded component variable avoids this conflict.

---
<a href="https://cursor.com/background-agent?bcId=bc-e1603e17-306a-48be-9ce0-6df736ae0fb1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e1603e17-306a-48be-9ce0-6df736ae0fb1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

