### PR TITLE
Handle dynamic import type error

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig(async ({ mode }) => {
 	}
 
 	return {
-		base: process.env.VITE_BASE || (mode === 'production' ? './' : '/'),
+		base: process.env.VITE_BASE || '/',
 		server: {
 			host: "::",
 			port: 8080,


### PR DESCRIPTION
Set Vite base path to absolute '/' to fix 'Failed to fetch dynamically imported module' errors on nested routes.

---
<a href="https://cursor.com/background-agent?bcId=bc-0ed60818-046d-4738-aecd-a68e72a51b68">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0ed60818-046d-4738-aecd-a68e72a51b68">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

