### PR TITLE
Fix infinite recursion in organization_users policy

### DIFF
--- a/supabase/migrations/20250927110000_fix_org_users_rls_recursion.sql
+++ b/supabase/migrations/20250927110000_fix_org_users_rls_recursion.sql
@@ -1,0 +1,89 @@
+-- Fix recursive RLS on public.organization_users by using SECURITY DEFINER helper functions
+
+-- 1) Helper functions that bypass RLS on organization_users
+CREATE OR REPLACE FUNCTION public.is_member_of_organization(org_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+	user_uuid uuid := auth.uid();
+	v_exists boolean;
+BEGIN
+	IF user_uuid IS NULL THEN
+		RETURN false;
+	END IF;
+
+	SELECT EXISTS (
+		SELECT 1
+		FROM public.organization_users ou
+		WHERE ou.organization_id = org_id
+			AND ou.user_id = user_uuid
+			AND ou.is_active = true
+	) INTO v_exists;
+
+	RETURN COALESCE(v_exists, false);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_admin_of_organization(org_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+	user_uuid uuid := auth.uid();
+	v_exists boolean;
+BEGIN
+	IF user_uuid IS NULL THEN
+		RETURN false;
+	END IF;
+
+	SELECT EXISTS (
+		SELECT 1
+		FROM public.organization_users ou
+		WHERE ou.organization_id = org_id
+			AND ou.user_id = user_uuid
+			AND ou.is_active = true
+			AND ou.role IN ('owner','admin')
+	) INTO v_exists;
+
+	RETURN COALESCE(v_exists, false);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.is_member_of_organization(uuid) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.is_admin_of_organization(uuid) TO anon, authenticated;
+
+-- 2) Ensure RLS is enabled on organization_users
+ALTER TABLE public.organization_users ENABLE ROW LEVEL SECURITY;
+
+-- 3) Replace recursive policies with function-based policies
+DROP POLICY IF EXISTS org_users_select_by_org ON public.organization_users;
+DROP POLICY IF EXISTS org_users_insert_by_admin ON public.organization_users;
+DROP POLICY IF EXISTS org_users_update_by_admin ON public.organization_users;
+DROP POLICY IF EXISTS org_users_delete_by_admin ON public.organization_users;
+
+CREATE POLICY org_users_select_by_org ON public.organization_users
+	FOR SELECT USING (
+		public.is_member_of_organization(organization_id)
+	);
+
+CREATE POLICY org_users_insert_by_admin ON public.organization_users
+	FOR INSERT WITH CHECK (
+		public.is_admin_of_organization(organization_id)
+	);
+
+CREATE POLICY org_users_update_by_admin ON public.organization_users
+	FOR UPDATE USING (
+		public.is_admin_of_organization(organization_id)
+	) WITH CHECK (
+		public.is_admin_of_organization(organization_id)
+	);
+
+CREATE POLICY org_users_delete_by_admin ON public.organization_users
+	FOR DELETE USING (
+		public.is_admin_of_organization(organization_id)
+	);


### PR DESCRIPTION
Fixes infinite recursion in `organization_users` RLS policies by replacing self-referential checks with `SECURITY DEFINER` helper functions.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f3ec042-1047-4e7a-aeec-15dc5e8a26b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7f3ec042-1047-4e7a-aeec-15dc5e8a26b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

