### PR TITLE
Handle profile row security violation

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -99,10 +99,10 @@ const Profile = () => {
         email: profileData.email,
         phone: profileData.phone,
       };
-      // Upsert based on user_id
+      // Upsert profile ensuring id matches auth.uid() for RLS
       const { error } = await supabase
         .from('profiles')
-        .upsert({ user_id: user?.id as string, ...payload }, { onConflict: 'user_id' } as any);
+        .upsert({ id: user?.id as string, user_id: user?.id as string, ...payload }, { onConflict: 'id' } as any);
       if (error) throw error;
       toast.success('Profile updated successfully');
       setIsEditing(false);


### PR DESCRIPTION
Update profile upsert to include `id` and match RLS policy for the `profiles` table.

---
<a href="https://cursor.com/background-agent?bcId=bc-ad45b44f-8763-43c5-9010-ef56d85814ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ad45b44f-8763-43c5-9010-ef56d85814ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

