### PR TITLE
Add organization-specific service category management

### DIFF
--- a/setup_database.sql
+++ b/setup_database.sql
@@ -123,7 +123,8 @@ DECLARE
         'account_transactions', 'sales', 'sale_items', 'invoices', 
         'invoice_items', 'inventory_adjustments', 'inventory_adjustment_items', 'staff_commissions',
         'organizations', 'organization_users', 'organization_subscriptions',
-        'subscription_plans', 'user_invitations', 'super_admins'
+        'subscription_plans', 'user_invitations', 'super_admins',
+        'service_categories'
     ];
     table_name TEXT;
     table_exists BOOLEAN;

--- a/src/components/services/ServiceCategoriesManager.tsx
+++ b/src/components/services/ServiceCategoriesManager.tsx
@@ -1,0 +1,187 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { toast } from "sonner";
+
+interface ServiceCategory {
+  id: string;
+  name: string;
+  description?: string | null;
+  is_active: boolean;
+}
+
+interface ServiceCategoriesManagerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  organizationId: string;
+  onChanged?: () => void;
+}
+
+export default function ServiceCategoriesManager({ open, onOpenChange, organizationId, onChanged }: ServiceCategoriesManagerProps) {
+  const [loading, setLoading] = useState(false);
+  const [categories, setCategories] = useState<ServiceCategory[]>([]);
+  const [newName, setNewName] = useState("");
+  const [newDescription, setNewDescription] = useState("");
+
+  const fetchCategories = async () => {
+    try {
+      if (!organizationId) return;
+      setLoading(true);
+      const { data, error } = await (supabase as any)
+        .from("service_categories")
+        .select("id, name, description, is_active")
+        .eq("organization_id", organizationId)
+        .order("name");
+      if (error) throw error;
+      setCategories(data || []);
+    } catch (e: any) {
+      console.warn("Failed to load service categories", e?.message || e);
+      setCategories([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (open) fetchCategories();
+  }, [open]);
+
+  const handleCreate = async () => {
+    try {
+      if (!newName.trim()) {
+        toast.error("Category name is required");
+        return;
+      }
+      setLoading(true);
+      const { error } = await (supabase as any)
+        .from("service_categories")
+        .insert([{ name: newName.trim(), description: newDescription || null, organization_id: organizationId }]);
+      if (error) throw error;
+      toast.success("Category created");
+      setNewName("");
+      setNewDescription("");
+      await fetchCategories();
+      onChanged?.();
+    } catch (e: any) {
+      const msg = e?.message || String(e);
+      if (/duplicate key/i.test(msg) || /unique/i.test(msg)) {
+        toast.error("A category with this name already exists");
+      } else {
+        toast.error("Failed to create category");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRename = async (cat: ServiceCategory, newCatName: string) => {
+    try {
+      const trimmed = newCatName.trim();
+      if (!trimmed || trimmed === cat.name) return;
+      setLoading(true);
+      // Update services referencing this category to keep them in sync
+      const { error: svcErr } = await supabase
+        .from("services")
+        .update({ category: trimmed })
+        .eq("organization_id", organizationId)
+        .eq("category", cat.name);
+      if (svcErr) throw svcErr;
+      // Update the category record
+      const { error } = await (supabase as any)
+        .from("service_categories")
+        .update({ name: trimmed })
+        .eq("id", cat.id);
+      if (error) throw error;
+      toast.success("Category renamed");
+      await fetchCategories();
+      onChanged?.();
+    } catch (e: any) {
+      const msg = e?.message || String(e);
+      if (/duplicate key/i.test(msg) || /unique/i.test(msg)) {
+        toast.error("A category with this name already exists");
+      } else {
+        toast.error("Failed to rename category");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async (cat: ServiceCategory) => {
+    try {
+      setLoading(true);
+      const { count, error: cntErr } = await supabase
+        .from("services")
+        .select("id", { head: true, count: "exact" })
+        .eq("organization_id", organizationId)
+        .eq("category", cat.name);
+      if (cntErr) throw cntErr;
+      if ((count || 0) > 0) {
+        toast.error("Cannot delete: category is used by existing services");
+        return;
+      }
+      const { error } = await (supabase as any)
+        .from("service_categories")
+        .delete()
+        .eq("id", cat.id);
+      if (error) throw error;
+      toast.success("Category deleted");
+      await fetchCategories();
+      onChanged?.();
+    } catch (e: any) {
+      toast.error("Failed to delete category");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[700px]">
+        <DialogHeader>
+          <DialogTitle>Manage Service Categories</DialogTitle>
+          <DialogDescription>
+            Create and edit categories for this organization. Names must be unique per organization.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 py-2">
+          <div className="space-y-3">
+            <Label htmlFor="new-name">Create Category</Label>
+            <Input id="new-name" placeholder="Category name" value={newName} onChange={e => setNewName(e.target.value)} />
+            <Textarea placeholder="Description (optional)" value={newDescription} onChange={e => setNewDescription(e.target.value)} />
+            <div>
+              <Button onClick={handleCreate} disabled={loading}>Add Category</Button>
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <Label>Existing Categories</Label>
+              <Button variant="outline" size="sm" onClick={fetchCategories} disabled={loading}>Refresh</Button>
+            </div>
+            <div className="space-y-2 max-h-[300px] overflow-auto pr-1">
+              {categories.length === 0 && (
+                <div className="text-sm text-muted-foreground">No categories yet</div>
+              )}
+              {categories.map(cat => (
+                <div key={cat.id} className="flex items-center gap-2">
+                  <Input defaultValue={cat.name} onBlur={(e) => handleRename(cat, e.target.value)} className="flex-1" />
+                  <Button variant="destructive" onClick={() => handleDelete(cat)} disabled={loading}>Delete</Button>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>Close</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/supabase/migrations/20251001094500_service_categories.sql
+++ b/supabase/migrations/20251001094500_service_categories.sql
@@ -1,0 +1,82 @@
+-- Service Categories per Organization
+-- Creates `service_categories` table and enforces per-org uniqueness
+
+-- 1) Table
+CREATE TABLE IF NOT EXISTS public.service_categories (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name TEXT NOT NULL,
+    description TEXT,
+    is_active BOOLEAN DEFAULT true,
+    organization_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE (organization_id, name)
+);
+
+-- 2) Indexes
+CREATE INDEX IF NOT EXISTS idx_service_categories_org ON public.service_categories(organization_id);
+CREATE INDEX IF NOT EXISTS idx_service_categories_name ON public.service_categories(name);
+
+-- 2b) Seed from existing services (distinct names per org)
+INSERT INTO public.service_categories (organization_id, name, description, is_active)
+SELECT DISTINCT s.organization_id, s.category, NULL, true
+FROM public.services s
+WHERE s.category IS NOT NULL AND s.category <> ''
+ON CONFLICT (organization_id, name) DO NOTHING;
+
+-- 3) RLS
+ALTER TABLE public.service_categories ENABLE ROW LEVEL SECURITY;
+
+-- SELECT policy
+DROP POLICY IF EXISTS "Users can view service categories" ON public.service_categories;
+CREATE POLICY "Users can view service categories" ON public.service_categories
+    FOR SELECT
+    USING (
+        organization_id IN (
+            SELECT organization_id FROM public.organization_users
+            WHERE user_id = auth.uid() AND is_active = true
+        )
+    );
+
+-- INSERT policy
+DROP POLICY IF EXISTS "Users can insert service categories" ON public.service_categories;
+CREATE POLICY "Users can insert service categories" ON public.service_categories
+    FOR INSERT
+    WITH CHECK (
+        organization_id IN (
+            SELECT organization_id FROM public.organization_users
+            WHERE user_id = auth.uid() AND role IN ('owner','admin','manager','staff') AND is_active = true
+        )
+    );
+
+-- UPDATE policy
+DROP POLICY IF EXISTS "Users can update service categories" ON public.service_categories;
+CREATE POLICY "Users can update service categories" ON public.service_categories
+    FOR UPDATE
+    USING (
+        organization_id IN (
+            SELECT organization_id FROM public.organization_users
+            WHERE user_id = auth.uid() AND role IN ('owner','admin','manager','staff') AND is_active = true
+        )
+    );
+
+-- DELETE policy
+DROP POLICY IF EXISTS "Admins can delete service categories" ON public.service_categories;
+CREATE POLICY "Admins can delete service categories" ON public.service_categories
+    FOR DELETE
+    USING (
+        organization_id IN (
+            SELECT organization_id FROM public.organization_users
+            WHERE user_id = auth.uid() AND role IN ('owner','admin') AND is_active = true
+        )
+    );
+
+-- 4) updated_at trigger
+DROP TRIGGER IF EXISTS update_service_categories_updated_at ON public.service_categories;
+CREATE TRIGGER update_service_categories_updated_at
+    BEFORE UPDATE ON public.service_categories
+    FOR EACH ROW
+    EXECUTE FUNCTION public.update_updated_at_column();
+
+-- 5) Grants
+GRANT ALL ON public.service_categories TO authenticated;


### PR DESCRIPTION
Add per-organization service category management with create, edit, and delete functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-2ce86fe7-eaab-4f1c-98d7-b4051212fd98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2ce86fe7-eaab-4f1c-98d7-b4051212fd98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

