### PR TITLE
Match sidebar dark mode to app body

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -107,7 +107,7 @@ All colors MUST be HSL.
     --border: 217 32% 18%;
     --input: 217 32% 18%;
     --ring: 211 100% 50%;
-    --sidebar-background: 240 5.9% 10%;
+    --sidebar-background: var(--background);
     --sidebar-foreground: 240 4.8% 95.9%;
     --sidebar-primary: 224.3 76.3% 48%;
     --sidebar-primary-foreground: 0 0% 100%;


### PR DESCRIPTION
Aligns the dark mode sidebar background with the app body background.

---
<a href="https://cursor.com/background-agent?bcId=bc-740cb12d-68a5-40b9-9771-4c9ce9618306">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-740cb12d-68a5-40b9-9771-4c9ce9618306">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

