### PR TITLE
Rebuild dark mode metric card colors

### DIFF
--- a/src/components/features/UsageDashboard.tsx
+++ b/src/components/features/UsageDashboard.tsx
@@ -184,9 +184,9 @@ export const UsageDashboard: React.FC<UsageDashboardProps> = ({
             <Card 
               key={feature} 
               className={`border-l-4 ${
-                status.status === 'disabled' ? 'border-l-slate-400 bg-slate-50' :
-                status.status === 'full' ? 'border-l-red-500 bg-red-50' :
-                status.status === 'warning' ? 'border-l-amber-500 bg-amber-50' :
+                status.status === 'disabled' ? 'border-l-slate-400 bg-slate-500/10' :
+                status.status === 'full' ? 'border-l-red-500 bg-red-500/10' :
+                status.status === 'warning' ? 'border-l-amber-500 bg-amber-500/10' :
                 'border-l-emerald-500'
               }`}
             >
@@ -266,7 +266,7 @@ export const UsageDashboard: React.FC<UsageDashboardProps> = ({
         <CardContent className="space-y-4">
           {isTrialing && daysLeftInTrial !== null && (
             <div className={`p-4 rounded-lg border ${
-              daysLeftInTrial <= 3 ? 'bg-red-50 border-red-200' : 'bg-amber-50 border-amber-200'
+              daysLeftInTrial <= 3 ? 'bg-red-500/10 border-red-300' : 'bg-amber-500/10 border-amber-300'
             }`}>
               <div className="flex items-center justify-between">
                 <div>
@@ -295,7 +295,7 @@ export const UsageDashboard: React.FC<UsageDashboardProps> = ({
           )}
 
           {featuresNeedingAttention.length > 0 && (
-            <div className="p-4 bg-amber-50 border border-amber-200 rounded-lg">
+            <div className="p-4 bg-amber-500/10 border border-amber-300 rounded-lg">
               <div className="flex items-center gap-2 mb-2">
                 <AlertTriangle className="w-4 h-4 text-amber-600" />
                 <h4 className="font-medium text-amber-800">Attention Required</h4>
@@ -316,7 +316,7 @@ export const UsageDashboard: React.FC<UsageDashboardProps> = ({
           )}
 
           {disabledFeatures.length > 0 && showUpgrade && (
-            <div className="p-4 bg-violet-50 border border-violet-200 rounded-lg">
+            <div className="p-4 bg-violet-500/10 border border-violet-300 rounded-lg">
               <div className="flex items-center gap-2 mb-2">
                 <Zap className="w-4 h-4 text-violet-600" />
                 <h4 className="font-medium text-violet-800">Unlock More Features</h4>

--- a/src/index.css
+++ b/src/index.css
@@ -77,10 +77,10 @@ All colors MUST be HSL.
     --foreground: 210 40% 98%;
     color-scheme: dark;
 
-    --card: 220 39% 11%;
+    --card: 220 25% 14%;
     --card-foreground: 210 40% 98%;
 
-    --popover: 220 39% 11%;
+    --popover: 220 25% 14%;
     --popover-foreground: 210 40% 98%;
 
     --primary: 211 100% 50%;

--- a/src/pages/InvoiceCreate.tsx
+++ b/src/pages/InvoiceCreate.tsx
@@ -405,7 +405,7 @@ export default function InvoiceCreate() {
             <Receipt className="w-4 h-4 text-green-600" />
             Invoice Items
           </h3>
-          <Card className="bg-slate-50 border-slate-200">
+          <Card className="bg-slate-500/10 border-slate-200">
             <CardHeader className="pb-3">
               <CardTitle className="text-sm">Add Item</CardTitle>
             </CardHeader>

--- a/src/pages/InvoiceEdit.tsx
+++ b/src/pages/InvoiceEdit.tsx
@@ -312,7 +312,7 @@ export default function InvoiceEdit() {
             <Receipt className="w-4 h-4 text-green-600" />
             Invoice Items
           </h3>
-          <Card className="bg-slate-50 border-slate-200">
+          <Card className="bg-slate-500/10 border-slate-200">
             <CardHeader className="pb-3">
               <CardTitle className="text-sm">Add Item</CardTitle>
             </CardHeader>

--- a/src/pages/Invoices.tsx
+++ b/src/pages/Invoices.tsx
@@ -940,7 +940,7 @@ export default function Invoices() {
             <div className="space-y-6">
               {/* Invoice Header */}
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <Card className="bg-blue-50 border-blue-200">
+                <Card className="bg-blue-500/10 border-blue-300">
                   <CardHeader className="pb-3">
                     <CardTitle className="text-sm text-blue-700 flex items-center gap-2">
                       <Users className="w-4 h-4" />
@@ -964,7 +964,7 @@ export default function Invoices() {
                   </CardContent>
                 </Card>
 
-                <Card className="bg-violet-50 border-violet-200">
+                <Card className="bg-violet-500/10 border-violet-300">
                   <CardHeader className="pb-3">
                     <CardTitle className="text-sm text-violet-700 flex items-center gap-2">
                       <Receipt className="w-4 h-4" />
@@ -1055,7 +1055,7 @@ export default function Invoices() {
               </Card>
 
               {/* Invoice Totals */}
-              <Card className="bg-slate-50">
+              <Card className="bg-slate-500/10">
                 <CardContent className="p-4">
                   <div className="flex justify-end">
                     <div className="w-64 space-y-2">

--- a/src/pages/admin/AdminDashboard.tsx
+++ b/src/pages/admin/AdminDashboard.tsx
@@ -289,20 +289,20 @@ const AdminDashboard = () => {
         {/* Key Metrics */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           <Link to="/admin/organizations">
-            <Card className="hover:shadow-md transition-shadow cursor-pointer">
+            <Card className="bg-gradient-to-br from-blue-500 to-blue-600 text-white border-0 shadow-md hover:shadow-lg transition-shadow cursor-pointer">
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium">Organizations</CardTitle>
-                <Building className="h-4 w-4 text-muted-foreground" />
+                <CardTitle className="text-sm font-medium text-white/90">Organizations</CardTitle>
+                <Building className="h-4 w-4 text-white/80" />
               </CardHeader>
               <CardContent>
                 <div className="text-2xl font-bold">
                   {loading ? '...' : stats.organizations.total.toLocaleString()}
                 </div>
                 <div className="flex items-center justify-between mt-2">
-                  <span className="text-xs text-green-600">
+                  <span className="text-xs text-white/80">
                     +{stats.organizations.recent} this week
                   </span>
-                  <Badge variant="outline" className="text-xs">
+                  <Badge variant="outline" className="text-xs bg-white/10 text-white border-white/20">
                     {stats.organizations.active} active
                   </Badge>
                 </div>
@@ -311,20 +311,20 @@ const AdminDashboard = () => {
           </Link>
 
           <Link to="/admin/users">
-            <Card className="hover:shadow-md transition-shadow cursor-pointer">
+            <Card className="bg-gradient-to-br from-emerald-500 to-emerald-600 text-white border-0 shadow-md hover:shadow-lg transition-shadow cursor-pointer">
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium">Users</CardTitle>
-                <Users className="h-4 w-4 text-muted-foreground" />
+                <CardTitle className="text-sm font-medium text-white/90">Users</CardTitle>
+                <Users className="h-4 w-4 text-white/80" />
               </CardHeader>
               <CardContent>
                 <div className="text-2xl font-bold">
                   {loading ? '...' : stats.users.total.toLocaleString()}
                 </div>
                 <div className="flex items-center justify-between mt-2">
-                  <span className="text-xs text-green-600">
+                  <span className="text-xs text-white/80">
                     +{stats.users.recent} this week
                   </span>
-                  <Badge variant="outline" className="text-xs">
+                  <Badge variant="outline" className="text-xs bg-white/10 text-white border-white/20">
                     {stats.users.confirmed} confirmed
                   </Badge>
                 </div>
@@ -333,20 +333,20 @@ const AdminDashboard = () => {
           </Link>
 
           <Link to="/admin/subscription-plans">
-            <Card className="hover:shadow-md transition-shadow cursor-pointer">
+            <Card className="bg-gradient-to-br from-violet-500 to-violet-600 text-white border-0 shadow-md hover:shadow-lg transition-shadow cursor-pointer">
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium">Subscriptions</CardTitle>
-                <CreditCard className="h-4 w-4 text-muted-foreground" />
+                <CardTitle className="text-sm font-medium text-white/90">Subscriptions</CardTitle>
+                <CreditCard className="h-4 w-4 text-white/80" />
               </CardHeader>
               <CardContent>
                 <div className="text-2xl font-bold">
                   {loading ? '...' : stats.subscriptions.active.toLocaleString()}
                 </div>
                 <div className="flex items-center justify-between mt-2">
-                  <span className="text-xs text-blue-600">
+                  <span className="text-xs text-white/80">
                     {stats.subscriptions.trial} trial
                   </span>
-                  <Badge variant="outline" className="text-xs">
+                  <Badge variant="outline" className="text-xs bg-white/10 text-white border-white/20">
                     {formatCurrency(stats.subscriptions.revenue)}/mo
                   </Badge>
                 </div>
@@ -355,10 +355,10 @@ const AdminDashboard = () => {
           </Link>
 
           <Link to="/admin/business-data">
-            <Card className="hover:shadow-md transition-shadow cursor-pointer">
+            <Card className="bg-gradient-to-br from-indigo-500 to-indigo-600 text-white border-0 shadow-md hover:shadow-lg transition-shadow cursor-pointer">
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium">Business Data</CardTitle>
-                <Database className="h-4 w-4 text-muted-foreground" />
+                <CardTitle className="text-sm font-medium text-white/90">Business Data</CardTitle>
+                <Database className="h-4 w-4 text-white/80" />
               </CardHeader>
               <CardContent>
                 <div className="text-2xl font-bold">
@@ -367,11 +367,11 @@ const AdminDashboard = () => {
                     .toLocaleString()}
                 </div>
                 <div className="flex items-center justify-between mt-2">
-                  <span className="text-xs text-green-600">
+                  <span className="text-xs text-white/80">
                     +{Object.values(stats.businessData)
                       .reduce((sum, data) => sum + data.recent, 0)} this week
                   </span>
-                  <Badge variant="outline" className="text-xs">
+                  <Badge variant="outline" className="text-xs bg-white/10 text-white border-white/20">
                     All records
                   </Badge>
                 </div>


### PR DESCRIPTION
Rebuilds dark mode to make all metrics cards colored like light mode.

This ensures consistency in metric card appearance across light and dark themes by applying colored gradients to Admin Dashboard cards and `bg-*-500/10` tints to other metric/tinted cards. Dark theme card and popover backgrounds are also slightly lightened for better contrast.

---
<a href="https://cursor.com/background-agent?bcId=bc-0bc5ed11-1787-45ca-9566-4e6aea0b6323">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0bc5ed11-1787-45ca-9566-4e6aea0b6323">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

