### PR TITLE
Redesign dark mode with colored cards

### DIFF
--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      "rounded-lg border bg-card text-card-foreground shadow-sm dark:bg-gradient-to-br dark:from-primary/15 dark:to-primary/5 dark:border-primary/25",
       className
     )}
     {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -266,3 +266,9 @@ html, body, #root {
     background-image: none !important;
   }
 }
+
+@layer base {
+  .dark .bg-card:not([class*="bg-gradient-to-"]) {
+    background-image: linear-gradient(135deg, hsl(var(--primary) / 0.12), hsl(var(--primary) / 0.03));
+  }
+}


### PR DESCRIPTION
Redesign dark mode theme to add subtle colored gradients to cards across all pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-95642114-6bc5-46c6-bbf2-29bf5b2c7c5c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-95642114-6bc5-46c6-bbf2-29bf5b2c7c5c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

