### PR TITLE
Fix missing foreign key relationship for organization users

### DIFF
--- a/supabase/migrations/20251015000000_add_fk_org_users_to_profiles.sql
+++ b/supabase/migrations/20251015000000_add_fk_org_users_to_profiles.sql
@@ -1,0 +1,36 @@
+-- Add FK so PostgREST can embed profiles from organization_users
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'organization_users'
+  ) AND EXISTS (
+    SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'profiles'
+  ) THEN
+    -- Ensure the referenced unique constraint on profiles.user_id exists
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.table_constraints 
+      WHERE table_schema = 'public' 
+        AND table_name = 'profiles' 
+        AND constraint_type = 'UNIQUE'
+        AND constraint_name = 'profiles_user_id_key'
+    ) THEN
+      ALTER TABLE public.profiles ADD CONSTRAINT profiles_user_id_key UNIQUE (user_id);
+    END IF;
+
+    -- Add FK from organization_users.user_id -> profiles.user_id if missing
+    IF NOT EXISTS (
+      SELECT 1
+      FROM information_schema.table_constraints tc
+      WHERE tc.table_schema = 'public'
+        AND tc.table_name = 'organization_users'
+        AND tc.constraint_name = 'organization_users_user_id_profiles_fkey'
+    ) THEN
+      ALTER TABLE public.organization_users
+        ADD CONSTRAINT organization_users_user_id_profiles_fkey
+        FOREIGN KEY (user_id)
+        REFERENCES public.profiles(user_id)
+        ON DELETE CASCADE;
+    END IF;
+  END IF;
+END $$;
+


### PR DESCRIPTION
Fixes `PGRST200` error by separating `organization_users` and `profiles` fetches and adding a missing foreign key.

The `PGRST200` error occurred because PostgREST could not find a foreign key relationship between `organization_users` and `profiles` when attempting an embedded join. The UI was updated to fetch these tables separately as an immediate workaround. A database migration was also added to establish the correct foreign key, ensuring future embedded queries work as expected and improving database schema integrity.

---
<a href="https://cursor.com/background-agent?bcId=bc-2ae3aa58-bc94-4103-9427-20c633410238">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2ae3aa58-bc94-4103-9427-20c633410238">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

