### PR TITLE
Fix job card initial data loading

### DIFF
--- a/supabase/migrations/20251015093000_job_cards_unique_per_org.sql
+++ b/supabase/migrations/20251015093000_job_cards_unique_per_org.sql
@@ -1,0 +1,50 @@
+-- Ensure job card numbers are unique per organization (not globally)
+DO $$
+BEGIN
+  -- Drop existing unique constraint on job_cards.job_number if it exists
+  IF EXISTS (
+    SELECT 1 FROM information_schema.table_constraints 
+    WHERE table_schema = 'public' 
+      AND table_name = 'job_cards' 
+      AND constraint_type = 'UNIQUE' 
+      AND constraint_name IN ('job_cards_job_number_key', 'job_cards_job_number_unique')
+  ) THEN
+    BEGIN
+      ALTER TABLE public.job_cards DROP CONSTRAINT IF EXISTS job_cards_job_number_key;
+    EXCEPTION WHEN undefined_object THEN
+      -- Ignore if already dropped
+      NULL;
+    END;
+  END IF;
+
+  -- Add a unique constraint on (organization_id, job_number)
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints 
+    WHERE table_schema = 'public' 
+      AND table_name = 'job_cards' 
+      AND constraint_type = 'UNIQUE' 
+      AND constraint_name = 'job_cards_org_job_number_key'
+  ) THEN
+    BEGIN
+      ALTER TABLE public.job_cards
+        ADD CONSTRAINT job_cards_org_job_number_key UNIQUE (organization_id, job_number);
+    EXCEPTION WHEN duplicate_table THEN
+      -- Created concurrently elsewhere
+      NULL;
+    WHEN others THEN
+      -- If there are duplicates across orgs, raise a clear message
+      RAISE EXCEPTION USING MESSAGE = 'Cannot add unique constraint (organization_id, job_number) on job_cards due to duplicate rows. Please deduplicate job numbers per organization before applying.';
+    END;
+  END IF;
+END $$;
+
+-- Helpful index to keep lookups fast
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'idx_job_cards_org_job_number'
+  ) THEN
+    CREATE INDEX idx_job_cards_org_job_number ON public.job_cards(organization_id, job_number);
+  END IF;
+END $$;
+


### PR DESCRIPTION
Fixes 'failed to load initial data' when creating job cards by enforcing organization-scoped data queries and inserts.

Row-Level Security (RLS) policies in the database require `organization_id` for data access. Previously, initial data loads and new job card/receipt inserts were not consistently including this filter, leading to data retrieval failures or insert rejections. This PR ensures all relevant operations are scoped to the active organization, and also updates the `job_cards` table to enforce job number uniqueness per organization rather than globally.

---
<a href="https://cursor.com/background-agent?bcId=bc-8276de28-63ab-4b3a-8a96-ae71f457d148">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8276de28-63ab-4b3a-8a96-ae71f457d148">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

