### PR TITLE
Enforce unique appointments per organization timeslot

### DIFF
--- a/supabase/migrations/20251016090000_enforce_unique_appointments_per_org.sql
+++ b/supabase/migrations/20251016090000_enforce_unique_appointments_per_org.sql
@@ -1,4 +1,39 @@
--- Enforce per-organization uniqueness for appointments by staff timeslot
+-- 0) Ensure organization_id exists on appointments and is backfilled
+DO $$
+BEGIN
+  -- Add column if missing
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_schema = 'public' AND table_name = 'appointments' AND column_name = 'organization_id'
+  ) THEN
+    ALTER TABLE public.appointments ADD COLUMN organization_id uuid;
+  END IF;
+
+  -- Backfill from staff
+  UPDATE public.appointments a
+  SET organization_id = s.organization_id
+  FROM public.staff s
+  WHERE a.organization_id IS NULL AND a.staff_id = s.id;
+
+  -- Backfill from clients
+  UPDATE public.appointments a
+  SET organization_id = c.organization_id
+  FROM public.clients c
+  WHERE a.organization_id IS NULL AND a.client_id = c.id;
+
+  -- Backfill from services
+  UPDATE public.appointments a
+  SET organization_id = sv.organization_id
+  FROM public.services sv
+  WHERE a.organization_id IS NULL AND a.service_id = sv.id;
+
+  -- Try to enforce NOT NULL if possible; ignore if some rows remain NULL
+  BEGIN
+    ALTER TABLE public.appointments ALTER COLUMN organization_id SET NOT NULL;
+  EXCEPTION WHEN others THEN
+    NULL;
+  END;
+END $$;
 
 -- 1) De-duplicate existing rows that conflict on (organization_id, staff_id, appointment_date, appointment_time)
 WITH ranked AS (
@@ -14,7 +49,7 @@ WITH ranked AS (
       ORDER BY created_at, id
     ) AS rn
   FROM public.appointments
-  WHERE staff_id IS NOT NULL
+  WHERE staff_id IS NOT NULL AND organization_id IS NOT NULL
 ), to_delete AS (
   SELECT id FROM ranked WHERE rn > 1
 )
@@ -25,5 +60,5 @@ WHERE a.id = d.id;
 -- 2) Create a partial unique index to prevent future duplicates
 CREATE UNIQUE INDEX IF NOT EXISTS ux_appointments_org_staff_slot
   ON public.appointments(organization_id, staff_id, appointment_date, appointment_time)
-  WHERE staff_id IS NOT NULL;
+  WHERE staff_id IS NOT NULL AND organization_id IS NOT NULL;
 


### PR DESCRIPTION
Add `organization_id` to `appointments` and enforce per-organization unique appointments by staff timeslot.

---
<a href="https://cursor.com/background-agent?bcId=bc-99014302-e45c-4b77-8d18-529729457672">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-99014302-e45c-4b77-8d18-529729457672">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

