### PR TITLE
Fix undefined inventory by item id

### DIFF
--- a/src/pages/CreateJobCard.tsx
+++ b/src/pages/CreateJobCard.tsx
@@ -959,6 +959,7 @@ export default function CreateJobCard() {
               serviceKits={serviceKits}
               productsUsed={jobCardData.products_used}
               productCosts={productCosts}
+              inventoryByItemId={inventoryByItemId}
               onQuantityChange={updateProductQuantity}
               onNext={nextStep}
               onPrev={prevStep}
@@ -1503,6 +1504,7 @@ interface StepProductsMaterialsProps {
   serviceKits: ServiceKit[];
   productsUsed: { [key: string]: number };
   productCosts: number;
+  inventoryByItemId: Record<string, number>;
   onQuantityChange: (productId: string, quantity: number) => void;
   onNext: () => void;
   onPrev: () => void;
@@ -1513,6 +1515,7 @@ function StepProductsMaterials({
   serviceKits,
   productsUsed,
   productCosts,
+  inventoryByItemId,
   onQuantityChange,
   onNext,
   onPrev,


### PR DESCRIPTION
Pass `inventoryByItemId` as a prop to `StepProductsMaterials` to resolve a ReferenceError.

---
<a href="https://cursor.com/background-agent?bcId=bc-3845fead-3e8e-4265-8791-365927b511c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3845fead-3e8e-4265-8791-365927b511c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

