### PR TITLE
Ensure unique customers per organization

### DIFF
--- a/supabase/migrations/20251017093000_clients_unique_per_org.sql
+++ b/supabase/migrations/20251017093000_clients_unique_per_org.sql
@@ -1,0 +1,44 @@
+-- Enforce unique clients per organization (by phone), allowing multiple NULLs
+-- 1) Deduplicate existing rows that conflict on (organization_id, phone)
+DO $$
+DECLARE
+  dup_count INTEGER;
+BEGIN
+  -- Count duplicates where phone IS NOT NULL
+  SELECT COUNT(*) INTO dup_count
+  FROM (
+    SELECT organization_id, phone
+    FROM public.clients
+    WHERE phone IS NOT NULL
+    GROUP BY organization_id, phone
+    HAVING COUNT(*) > 1
+  ) d;
+
+  IF dup_count > 0 THEN
+    -- Strategy: Keep the earliest created row per (organization_id, phone), nullify phone for the rest
+    WITH ranked AS (
+      SELECT 
+        id,
+        organization_id,
+        phone,
+        created_at,
+        ROW_NUMBER() OVER (PARTITION BY organization_id, phone ORDER BY created_at NULLS LAST, id) AS rn
+      FROM public.clients
+      WHERE phone IS NOT NULL
+    )
+    UPDATE public.clients c
+    SET phone = NULL
+    FROM ranked r
+    WHERE c.id = r.id
+      AND r.rn > 1;
+  END IF;
+END $$;
+
+-- 2) Create a partial unique index to prevent future duplicates per org when phone is provided
+CREATE UNIQUE INDEX IF NOT EXISTS ux_clients_org_phone
+ON public.clients(organization_id, phone)
+WHERE phone IS NOT NULL;
+
+-- Optional: also keep a helpful lookup index by organization_id for faster filtering if not already present
+CREATE INDEX IF NOT EXISTS idx_clients_organization_id ON public.clients(organization_id);
+


### PR DESCRIPTION
Enforce per-organization uniqueness for clients by phone number.

This PR adds a database migration to deduplicate existing conflicts and create a partial unique index on `(organization_id, phone) WHERE phone IS NOT NULL`. The client creation and update logic in the frontend is also updated to catch unique constraint violations and provide user-friendly feedback.

---
<a href="https://cursor.com/background-agent?bcId=bc-89db18d6-505b-4f0b-996d-7d70eb07a6fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-89db18d6-505b-4f0b-996d-7d70eb07a6fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

