### PR TITLE
Resolve ambiguous job number column

### DIFF
--- a/supabase/migrations/20251020093000_fix_generate_job_number_ambiguous.sql
+++ b/supabase/migrations/20251020093000_fix_generate_job_number_ambiguous.sql
@@ -1,0 +1,24 @@
+-- Fix ambiguous column reference caused by PL/pgSQL variable name "job_number"
+-- Replace the function to use a distinct variable name and qualify the column
+
+CREATE OR REPLACE FUNCTION public.generate_job_number(p_organization_id uuid)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+    next_number INTEGER;
+    v_job_number TEXT;
+BEGIN
+    SELECT COALESCE(MAX(CAST(SUBSTRING(jc.job_number FROM 'JC(\d+)') AS INTEGER)), 0) + 1
+    INTO next_number
+    FROM public.job_cards AS jc
+    WHERE jc.organization_id = p_organization_id
+      AND jc.job_number ~ '^JC\d+$';
+
+    v_job_number := 'JC' || LPAD(next_number::TEXT, 3, '0');
+    RETURN v_job_number;
+END;
+$$;
+


### PR DESCRIPTION
Fix ambiguous column reference in `generate_job_number` function by renaming a local variable and qualifying the column.

---
<a href="https://cursor.com/background-agent?bcId=bc-79a995e6-b93b-4813-a3f7-1417b991372c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-79a995e6-b93b-4813-a3f7-1417b991372c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

