### PR TITLE
Color and resize payment tabs

### DIFF
--- a/src/pages/Payments.tsx
+++ b/src/pages/Payments.tsx
@@ -465,9 +465,19 @@ export default function Payments() {
       </div>
 
       <Tabs defaultValue="received" className="w-full">
-        <TabsList className="grid w-full grid-cols-2 md:w-auto">
-          <TabsTrigger value="received">Payments Received</TabsTrigger>
-          <TabsTrigger value="made">Payments Made</TabsTrigger>
+        <TabsList className="grid w-full grid-cols-2 md:w-auto h-12">
+          <TabsTrigger
+            value="received"
+            className="px-5 py-3 text-base text-green-700 data-[state=active]:!bg-green-600 data-[state=active]:!text-white data-[state=active]:shadow-sm"
+          >
+            Payments Received
+          </TabsTrigger>
+          <TabsTrigger
+            value="made"
+            className="px-5 py-3 text-base text-red-700 data-[state=active]:!bg-red-600 data-[state=active]:!text-white data-[state=active]:shadow-sm"
+          >
+            Payments Made
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent value="received" className="space-y-6">


### PR DESCRIPTION
Update payments page tabs to be larger and colored green for 'Received' and red for 'Made'.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0305577-2d76-477f-8442-2238f02cbeec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0305577-2d76-477f-8442-2238f02cbeec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

