### PR TITLE
Fix dynamic import fetch error for job cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,6 @@
     <meta name="twitter:site" content="@app" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
 
-    <base href="/" />
 
     <meta name="theme-color" content="#0b0f14" media="(prefers-color-scheme: dark)" />
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,8 @@ import { componentTagger } from "lovable-tagger";
 export default defineConfig(({ mode }) => {
 
 	return {
-		base: process.env.VITE_BASE || '/',
+		// Use relative base by default so assets/chunks load correctly on sub-path previews
+		base: process.env.VITE_BASE ?? './',
 		server: {
 			host: "::",
 			port: 8080,


### PR DESCRIPTION
Configure Vite to use relative asset paths and remove the base tag to resolve dynamic module import errors.

The previous configuration with `<base href="/">` and an absolute Vite base caused dynamic imports (like `JobCards-*.js`) to attempt fetching from the root of the domain. This led to `TypeError: Failed to fetch dynamically imported module` when the application was deployed to a subpath (e.g., a preview environment URL). By using a relative base, asset URLs are resolved correctly regardless of the deployment path.

---
<a href="https://cursor.com/background-agent?bcId=bc-fedff766-6698-464b-94c1-8dd737d94087">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fedff766-6698-464b-94c1-8dd737d94087">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

