### PR TITLE
Shrink payments tabs on window

### DIFF
--- a/src/pages/Payments.tsx
+++ b/src/pages/Payments.tsx
@@ -465,16 +465,16 @@ export default function Payments() {
       </div>
 
       <Tabs defaultValue="received" className="w-full">
-        <TabsList className="grid w-full grid-cols-2 md:w-auto h-12">
+        <TabsList className="grid w-full grid-cols-2 md:w-auto h-9">
           <TabsTrigger
             value="received"
-            className="px-5 py-3 text-base text-green-700 data-[state=active]:!bg-green-600 data-[state=active]:!text-white data-[state=active]:shadow-sm"
+            className="px-3 py-2 text-sm text-green-700 data-[state=active]:!bg-green-600 data-[state=active]:!text-white data-[state=active]:shadow-sm"
           >
             Payments Received
           </TabsTrigger>
           <TabsTrigger
             value="made"
-            className="px-5 py-3 text-base text-red-700 data-[state=active]:!bg-red-600 data-[state=active]:!text-white data-[state=active]:shadow-sm"
+            className="px-3 py-2 text-sm text-red-700 data-[state=active]:!bg-red-600 data-[state=active]:!text-white data-[state=active]:shadow-sm"
           >
             Payments Made
           </TabsTrigger>


### PR DESCRIPTION
Reduce the size of "Payments received" and "Payments made" tabs on the payments window.

---
<a href="https://cursor.com/background-agent?bcId=bc-2dab1168-aa3c-4947-8a0c-0ae048d9cd10">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2dab1168-aa3c-4947-8a0c-0ae048d9cd10">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

