### PR TITLE
Fix payments date range selector display

### DIFF
--- a/src/pages/Payments.tsx
+++ b/src/pages/Payments.tsx
@@ -521,9 +521,11 @@ export default function Payments() {
                       )}
                     </Button>
                   </PopoverTrigger>
-                  <PopoverContent className="p-0" align="start">
+                  <PopoverContent className="w-auto p-0" align="start">
                     <Calendar
                       mode="range"
+                      initialFocus
+                      defaultMonth={dateRange?.from}
                       selected={dateRange}
                       onSelect={setDateRange}
                       numberOfMonths={2}


### PR DESCRIPTION
Fixes the date range selector display on the Payments page.

The popover width is now `w-auto` to accommodate the two-month calendar, and `initialFocus` and `defaultMonth` are added to the calendar for improved user experience and correct initial display.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f6b80a0-11f2-4b54-9b24-96b31c6985d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9f6b80a0-11f2-4b54-9b24-96b31c6985d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

