### PR TITLE
Validate stock transfers between warehouses

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1327,35 +1327,41 @@ export type Database = {
       inventory_transfers: {
         Row: {
           created_at: string
-          from_location_id: string
+          from_location_id: string | null
+          from_warehouse_id: string | null
           id: string
           item_id: string
           notes: string | null
           organization_id: string | null
           quantity: number
-          to_location_id: string
+          to_location_id: string | null
+          to_warehouse_id: string | null
           updated_at: string
         }
         Insert: {
           created_at?: string
-          from_location_id: string
+          from_location_id?: string | null
+          from_warehouse_id?: string | null
           id?: string
           item_id: string
           notes?: string | null
           organization_id?: string | null
           quantity: number
-          to_location_id: string
+          to_location_id?: string | null
+          to_warehouse_id?: string | null
           updated_at?: string
         }
         Update: {
           created_at?: string
-          from_location_id?: string
+          from_location_id?: string | null
+          from_warehouse_id?: string | null
           id?: string
           item_id?: string
           notes?: string | null
           organization_id?: string | null
           quantity?: number
-          to_location_id?: string
+          to_location_id?: string | null
+          to_warehouse_id?: string | null
           updated_at?: string
         }
         Relationships: [
@@ -1371,6 +1377,13 @@ export type Database = {
             columns: ["from_location_id"]
             isOneToOne: false
             referencedRelation: "storage_locations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "inventory_transfers_from_warehouse_id_fkey"
+            columns: ["from_warehouse_id"]
+            isOneToOne: false
+            referencedRelation: "warehouses"
             referencedColumns: ["id"]
           },
           {
@@ -1392,6 +1405,13 @@ export type Database = {
             columns: ["to_location_id"]
             isOneToOne: false
             referencedRelation: "storage_locations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "inventory_transfers_to_warehouse_id_fkey"
+            columns: ["to_warehouse_id"]
+            isOneToOne: false
+            referencedRelation: "warehouses"
             referencedColumns: ["id"]
           },
         ]

--- a/src/pages/StockTransfers.tsx
+++ b/src/pages/StockTransfers.tsx
@@ -21,38 +21,38 @@ import { DateRange } from "react-day-picker";
 import { useOrganizationCurrency, useOrganization } from "@/lib/saas/hooks";
 
 interface InventoryItem { id: string; name: string; cost_price?: number | null; selling_price?: number | null; unit?: string | null }
-interface Location { id: string; name: string; }
-interface LevelRow { id: string; item_id: string; location_id: string; quantity: number; inventory_items?: { name: string }; business_locations?: { name: string }; }
+interface Warehouse { id: string; name: string; }
+interface LevelRow { id: string; item_id: string; warehouse_id: string | null; quantity: number; inventory_items?: { name: string }; warehouses?: { name: string }; }
 
-interface TransferRow { id: string; item_id: string; from_location_id: string; to_location_id: string; quantity: number; created_at: string; updated_at: string; notes?: string; inventory_items?: { name: string; cost_price?: number | null; selling_price?: number | null; unit?: string | null }; from_location?: { name: string }; to_location?: { name: string }; }
+interface TransferRow { id: string; item_id: string; from_warehouse_id: string; to_warehouse_id: string; quantity: number; created_at: string; updated_at: string; notes?: string; inventory_items?: { name: string; cost_price?: number | null; selling_price?: number | null; unit?: string | null }; }
 
 export default function StockTransfers() {
   const { toast } = useToast();
   const { format: formatMoney } = useOrganizationCurrency();
   const { organization } = useOrganization();
   const [items, setItems] = useState<InventoryItem[]>([]);
-  const [locations, setLocations] = useState<Location[]>([]);
+  const [warehouses, setWarehouses] = useState<Warehouse[]>([]);
   const [levels, setLevels] = useState<LevelRow[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [transfers, setTransfers] = useState<TransferRow[]>([]);
   const [viewOpen, setViewOpen] = useState<boolean>(false);
   const [editOpen, setEditOpen] = useState<boolean>(false);
   const [selectedTransfer, setSelectedTransfer] = useState<TransferRow | null>(null);
-  const [editForm, setEditForm] = useState({ item_id: "", from_location_id: "", to_location_id: "", quantity: "", notes: "" });
+  const [editForm, setEditForm] = useState({ item_id: "", from_warehouse_id: "", to_warehouse_id: "", quantity: "", notes: "" });
 
-  const [form, setForm] = useState({ item_id: "", from_location_id: "", to_location_id: "", quantity: "" });
+  const [form, setForm] = useState({ item_id: "", from_warehouse_id: "", to_warehouse_id: "", quantity: "" });
   const qty = Number(form.quantity || 0);
 
-  // Ensure unique locations by name for dropdowns
-  const uniqueLocations = useMemo(() => {
+  // Ensure unique warehouses by name for dropdowns
+  const uniqueWarehouses = useMemo(() => {
     const seen = new Set<string>();
-    return locations.filter((loc) => {
-      const key = (loc.name || "").trim().toLowerCase();
+    return warehouses.filter((wh) => {
+      const key = (wh.name || "").trim().toLowerCase();
       if (seen.has(key)) return false;
       seen.add(key);
       return true;
     });
-  }, [locations]);
+  }, [warehouses]);
 
   // Listing filters and dashboard state
   const [searchText, setSearchText] = useState<string>("");
@@ -62,26 +62,26 @@ export default function StockTransfers() {
   const fetchRefs = useCallback(async () => {
     setLoading(true);
     try {
-      const [itemsRes, locsRes, levelsRes, transfersRes] = await Promise.all([
+      const [itemsRes, whRes, levelsRes, transfersRes] = await Promise.all([
         supabase.from("inventory_items").select("id, name, cost_price, selling_price, unit").eq("type", "good").eq("is_active", true).order("name"),
-        supabase.from("business_locations").select("id, name").eq('organization_id', organization?.id || '').order("name"),
+        supabase.from("warehouses").select("id, name").eq('organization_id', organization?.id || '').order("name"),
         supabase
           .from("inventory_levels")
           .select(
-            `id, item_id, location_id, quantity,
+            `id, item_id, warehouse_id, quantity,
              inventory_items(name),
-             business_locations(name)`
+             warehouses(name)`
           ),
         supabase
           .from("inventory_transfers")
           .select(
-            `id, item_id, from_location_id, to_location_id, quantity, created_at, updated_at, notes,
+            `id, item_id, from_warehouse_id, to_warehouse_id, quantity, created_at, updated_at, notes,
              inventory_items(name, cost_price, selling_price, unit)`
           )
           .order("created_at", { ascending: false }),
       ]);
       setItems(itemsRes.data || []);
-      setLocations(locsRes.data || []);
+      setWarehouses(whRes.data || []);
       setLevels((levelsRes.data || []) as LevelRow[]);
       setTransfers((transfersRes.data || []) as TransferRow[]);
     } catch (err) {
@@ -94,27 +94,27 @@ export default function StockTransfers() {
 
   useEffect(() => { fetchRefs(); }, [fetchRefs]);
 
-  const getAvailableQty = (itemId: string, locationId: string) => {
-    const row = levels.find(l => l.item_id === itemId && l.location_id === locationId);
+  const getAvailableQty = (itemId: string, warehouseId: string) => {
+    const row = levels.find(l => l.item_id === itemId && l.warehouse_id === warehouseId);
     return Number(row?.quantity || 0);
   };
 
   const submitTransfer = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!form.item_id || !form.from_location_id || !form.to_location_id || qty) {
+    if (!form.item_id || !form.from_warehouse_id || !form.to_warehouse_id || qty) {
       // keep original validations below
     }
-    if (!form.item_id || !form.from_location_id || !form.to_location_id || !qty) {
-      toast({ title: "Missing data", description: "Select item, locations and quantity", variant: "destructive" });
+    if (!form.item_id || !form.from_warehouse_id || !form.to_warehouse_id || !qty) {
+      toast({ title: "Missing data", description: "Select item, warehouses and quantity", variant: "destructive" });
       return;
     }
-    if (form.from_location_id === form.to_location_id) {
-      toast({ title: "Invalid selection", description: "From and To locations must differ", variant: "destructive" });
+    if (form.from_warehouse_id === form.to_warehouse_id) {
+      toast({ title: "Invalid selection", description: "From and To warehouses must differ", variant: "destructive" });
       return;
     }
-    const available = getAvailableQty(form.item_id, form.from_location_id);
+    const available = getAvailableQty(form.item_id, form.from_warehouse_id);
     if (qty > available) {
-      toast({ title: "Insufficient stock", description: `Only ${available} available at source location`, variant: "destructive" });
+      toast({ title: "Insufficient stock", description: `Only ${available} available at source warehouse`, variant: "destructive" });
       return;
     }
 
@@ -123,15 +123,15 @@ export default function StockTransfers() {
       await supabase.from("inventory_transfers").insert([
         {
           item_id: form.item_id,
-          from_location_id: form.from_location_id,
-          to_location_id: form.to_location_id,
+          from_warehouse_id: form.from_warehouse_id,
+          to_warehouse_id: form.to_warehouse_id,
           quantity: qty,
           notes: null,
         },
       ]);
 
-      toast({ title: "Transfer completed", description: "Stock moved between locations" });
-      setForm({ item_id: "", from_location_id: "", to_location_id: "", quantity: "" });
+      toast({ title: "Transfer completed", description: "Stock moved between warehouses" });
+      setForm({ item_id: "", from_warehouse_id: "", to_warehouse_id: "", quantity: "" });
       fetchRefs();
     } catch (err) {
       console.error(err);
@@ -148,8 +148,8 @@ export default function StockTransfers() {
     setSelectedTransfer(t);
     setEditForm({
       item_id: t.item_id,
-      from_location_id: t.from_location_id,
-      to_location_id: t.to_location_id,
+      from_warehouse_id: t.from_warehouse_id,
+      to_warehouse_id: t.to_warehouse_id,
       quantity: String(t.quantity || 0),
       notes: t.notes || "",
     });
@@ -159,7 +159,7 @@ export default function StockTransfers() {
   const saveEdit = async () => {
     if (!selectedTransfer) return;
     const newQty = Number(editForm.quantity || 0);
-    if (!editForm.item_id || !editForm.from_location_id || !editForm.to_location_id || newQty <= 0) {
+    if (!editForm.item_id || !editForm.from_warehouse_id || !editForm.to_warehouse_id || newQty <= 0) {
       toast({ title: "Missing data", description: "Fill all required fields", variant: "destructive" });
       return;
     }
@@ -172,7 +172,7 @@ export default function StockTransfers() {
         .from("inventory_levels")
         .select("id, quantity")
         .eq("item_id", orig.item_id)
-        .eq("location_id", orig.to_location_id)
+        .eq("warehouse_id", orig.to_warehouse_id)
         .limit(1);
       if (srcLevels && srcLevels.length > 0) {
         await supabase
@@ -184,7 +184,7 @@ export default function StockTransfers() {
         .from("inventory_levels")
         .select("id, quantity")
         .eq("item_id", orig.item_id)
-        .eq("location_id", orig.from_location_id)
+        .eq("warehouse_id", orig.from_warehouse_id)
         .limit(1);
       if (dstLevels && dstLevels.length > 0) {
         await supabase
@@ -194,7 +194,7 @@ export default function StockTransfers() {
       } else {
         await supabase
           .from("inventory_levels")
-          .insert([{ item_id: orig.item_id, location_id: orig.from_location_id, quantity: Number(orig.quantity || 0) }]);
+          .insert([{ item_id: orig.item_id, warehouse_id: orig.from_warehouse_id, quantity: Number(orig.quantity || 0) }]);
       }
 
       // Apply new inventory move
@@ -203,7 +203,7 @@ export default function StockTransfers() {
         .from("inventory_levels")
         .select("id, quantity")
         .eq("item_id", editForm.item_id)
-        .eq("location_id", editForm.from_location_id)
+        .eq("warehouse_id", editForm.from_warehouse_id)
         .limit(1);
       if (newSrc && newSrc.length > 0) {
         await supabase
@@ -216,7 +216,7 @@ export default function StockTransfers() {
         .from("inventory_levels")
         .select("id, quantity")
         .eq("item_id", editForm.item_id)
-        .eq("location_id", editForm.to_location_id)
+        .eq("warehouse_id", editForm.to_warehouse_id)
         .limit(1);
       if (newDst && newDst.length > 0) {
         await supabase
@@ -226,7 +226,7 @@ export default function StockTransfers() {
       } else {
         await supabase
           .from("inventory_levels")
-          .insert([{ item_id: editForm.item_id, location_id: editForm.to_location_id, quantity: newQty }]);
+          .insert([{ item_id: editForm.item_id, warehouse_id: editForm.to_warehouse_id, quantity: newQty }]);
       }
 
       // Update transfer record
@@ -234,8 +234,8 @@ export default function StockTransfers() {
         .from("inventory_transfers")
         .update({
           item_id: editForm.item_id,
-          from_location_id: editForm.from_location_id,
-          to_location_id: editForm.to_location_id,
+          from_warehouse_id: editForm.from_warehouse_id,
+          to_warehouse_id: editForm.to_warehouse_id,
           quantity: newQty,
           notes: editForm.notes || null,
         })
@@ -258,7 +258,7 @@ export default function StockTransfers() {
         .from("inventory_levels")
         .select("id, quantity")
         .eq("item_id", t.item_id)
-        .eq("location_id", t.to_location_id)
+        .eq("warehouse_id", t.to_warehouse_id)
         .limit(1);
       if (dst && dst.length > 0) {
         await supabase
@@ -270,7 +270,7 @@ export default function StockTransfers() {
         .from("inventory_levels")
         .select("id, quantity")
         .eq("item_id", t.item_id)
-        .eq("location_id", t.from_location_id)
+        .eq("warehouse_id", t.from_warehouse_id)
         .limit(1);
       if (src && src.length > 0) {
         await supabase
@@ -280,7 +280,7 @@ export default function StockTransfers() {
       } else {
         await supabase
           .from("inventory_levels")
-          .insert([{ item_id: t.item_id, location_id: t.from_location_id, quantity: Number(t.quantity || 0) }]);
+          .insert([{ item_id: t.item_id, warehouse_id: t.from_warehouse_id, quantity: Number(t.quantity || 0) }]);
       }
 
       await supabase.from("inventory_transfers").delete().eq("id", t.id);
@@ -308,8 +308,8 @@ export default function StockTransfers() {
       if (!inRange) return false;
       if (!s) return true;
       const itemName = t.inventory_items?.name || items.find((i) => i.id === t.item_id)?.name || "";
-      const fromName = locations.find((l) => l.id === t.from_location_id)?.name || "";
-      const toName = locations.find((l) => l.id === t.to_location_id)?.name || "";
+      const fromName = warehouses.find((w) => w.id === t.from_warehouse_id)?.name || "";
+      const toName = warehouses.find((w) => w.id === t.to_warehouse_id)?.name || "";
       return (
         itemName.toLowerCase().includes(s) ||
         fromName.toLowerCase().includes(s) ||
@@ -317,16 +317,16 @@ export default function StockTransfers() {
         (t.notes || "").toLowerCase().includes(s)
       );
     });
-  }, [transfers, searchText, dateRange, items, locations]);
+  }, [transfers, searchText, dateRange, items, warehouses]);
 
   const kpis = useMemo(() => {
     const totalTransfers = filteredTransfers.length;
     const totalQuantity = filteredTransfers.reduce((sum, t) => sum + Number(t.quantity || 0), 0);
     const uniqueItems = new Set(filteredTransfers.map((t) => t.item_id)).size;
-    const uniqueLocations = new Set(
-      filteredTransfers.flatMap((t) => [t.from_location_id, t.to_location_id])
+    const uniqueWarehouses = new Set(
+      filteredTransfers.flatMap((t) => [t.from_warehouse_id, t.to_warehouse_id])
     ).size;
-    return { totalTransfers, totalQuantity, uniqueItems, uniqueLocations };
+    return { totalTransfers, totalQuantity, uniqueItems, uniqueWarehouses };
   }, [filteredTransfers]);
 
   const applyQuickRange = (key: string) => {
@@ -361,7 +361,7 @@ export default function StockTransfers() {
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-3xl font-bold tracking-tight">Stock Transfers</h2>
-          <p className="text-muted-foreground">Move stock between locations and review historical transfers</p>
+          <p className="text-muted-foreground">Move stock between warehouses and review historical transfers</p>
         </div>
       </div>
 
@@ -399,11 +399,11 @@ export default function StockTransfers() {
         </Card>
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Locations Involved</CardTitle>
+            <CardTitle className="text-sm font-medium">Warehouses Involved</CardTitle>
             <MapPin className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{kpis.uniqueLocations}</div>
+            <div className="text-2xl font-bold">{kpis.uniqueWarehouses}</div>
             <p className="text-xs text-muted-foreground">Across transfers</p>
           </CardContent>
         </Card>
@@ -462,7 +462,7 @@ export default function StockTransfers() {
             <div className="relative">
               <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
               <Input
-                placeholder="Search by item, location, or notes"
+                placeholder="Search by item, warehouse, or notes"
                 value={searchText}
                 onChange={(e) => setSearchText(e.target.value)}
                 className="pl-8"
@@ -502,35 +502,35 @@ export default function StockTransfers() {
                   </Select>
                 </div>
                 <div className="space-y-2">
-                  <Label>From Location</Label>
-                  <Select value={form.from_location_id} onValueChange={(v) => setForm({ ...form, from_location_id: v })}>
+                  <Label>From Warehouse</Label>
+                  <Select value={form.from_warehouse_id} onValueChange={(v) => setForm({ ...form, from_warehouse_id: v })}>
                     <SelectTrigger>
                       <SelectValue placeholder="Select source" />
                     </SelectTrigger>
                     <SelectContent>
-                      {uniqueLocations.map((l) => (
-                        <SelectItem key={l.id} value={l.id}>
-                          {l.name}
+                      {uniqueWarehouses.map((w) => (
+                        <SelectItem key={w.id} value={w.id}>
+                          {w.name}
                         </SelectItem>
                       ))}
                     </SelectContent>
                   </Select>
-                  {form.item_id && form.from_location_id && (
+                  {form.item_id && form.from_warehouse_id && (
                     <div className="text-xs text-muted-foreground">
-                      Available: {getAvailableQty(form.item_id, form.from_location_id)}
+                      Available: {getAvailableQty(form.item_id, form.from_warehouse_id)}
                     </div>
                   )}
                 </div>
                 <div className="space-y-2">
-                  <Label>To Location</Label>
-                  <Select value={form.to_location_id} onValueChange={(v) => setForm({ ...form, to_location_id: v })}>
+                  <Label>To Warehouse</Label>
+                  <Select value={form.to_warehouse_id} onValueChange={(v) => setForm({ ...form, to_warehouse_id: v })}>
                     <SelectTrigger>
                       <SelectValue placeholder="Select destination" />
                     </SelectTrigger>
                     <SelectContent>
-                      {uniqueLocations.map((l) => (
-                        <SelectItem key={l.id} value={l.id}>
-                          {l.name}
+                      {uniqueWarehouses.map((w) => (
+                        <SelectItem key={w.id} value={w.id}>
+                          {w.name}
                         </SelectItem>
                       ))}
                     </SelectContent>
@@ -573,8 +573,8 @@ export default function StockTransfers() {
                         <TableRow key={t.id}>
                           <TableCell>{new Date(t.created_at).toLocaleString()}</TableCell>
                           <TableCell>{t.inventory_items?.name || items.find((i) => i.id === t.item_id)?.name || t.item_id}</TableCell>
-                          <TableCell>{locations.find((l) => l.id === t.from_location_id)?.name || t.from_location_id}</TableCell>
-                          <TableCell>{locations.find((l) => l.id === t.to_location_id)?.name || t.to_location_id}</TableCell>
+                          <TableCell>{warehouses.find((w) => w.id === t.from_warehouse_id)?.name || t.from_warehouse_id}</TableCell>
+                          <TableCell>{warehouses.find((w) => w.id === t.to_warehouse_id)?.name || t.to_warehouse_id}</TableCell>
                           <TableCell className="text-right">{Number(t.quantity || 0)}</TableCell>
                           <TableCell className="text-right">
                             <div className="flex justify-end">
@@ -646,16 +646,16 @@ export default function StockTransfers() {
                     <div className="p-4 grid grid-cols-1 sm:grid-cols-3 gap-4 items-center">
                       <div>
                         <div className="text-xs text-muted-foreground">From</div>
-                        <div className="font-medium">{locations.find((l) => l.id === selectedTransfer.from_location_id)?.name || selectedTransfer.from_location_id}</div>
-                        <div className="text-xs text-muted-foreground">Current stock: {getAvailableQty(selectedTransfer.item_id, selectedTransfer.from_location_id)}</div>
+                        <div className="font-medium">{warehouses.find((w) => w.id === selectedTransfer.from_warehouse_id)?.name || selectedTransfer.from_warehouse_id}</div>
+                        <div className="text-xs text-muted-foreground">Current stock: {getAvailableQty(selectedTransfer.item_id, selectedTransfer.from_warehouse_id)}</div>
                       </div>
                       <div className="flex items-center justify-center">
                         <ArrowRight className="h-5 w-5 text-muted-foreground" />
                       </div>
                       <div>
                         <div className="text-xs text-muted-foreground">To</div>
-                        <div className="font-medium">{locations.find((l) => l.id === selectedTransfer.to_location_id)?.name || selectedTransfer.to_location_id}</div>
-                        <div className="text-xs text-muted-foreground">Current stock: {getAvailableQty(selectedTransfer.item_id, selectedTransfer.to_location_id)}</div>
+                        <div className="font-medium">{warehouses.find((w) => w.id === selectedTransfer.to_warehouse_id)?.name || selectedTransfer.to_warehouse_id}</div>
+                        <div className="text-xs text-muted-foreground">Current stock: {getAvailableQty(selectedTransfer.item_id, selectedTransfer.to_warehouse_id)}</div>
                       </div>
                     </div>
                   </div>
@@ -766,30 +766,30 @@ export default function StockTransfers() {
               <Input type="number" min={0} value={editForm.quantity} onChange={(e) => setEditForm({ ...editForm, quantity: e.target.value })} />
             </div>
             <div className="space-y-2">
-              <Label>From Location</Label>
-              <Select value={editForm.from_location_id} onValueChange={(v) => setEditForm({ ...editForm, from_location_id: v })}>
+              <Label>From Warehouse</Label>
+              <Select value={editForm.from_warehouse_id} onValueChange={(v) => setEditForm({ ...editForm, from_warehouse_id: v })}>
                 <SelectTrigger>
                   <SelectValue placeholder="Select source" />
                 </SelectTrigger>
                 <SelectContent>
-                  {uniqueLocations.map((l) => (
-                    <SelectItem key={l.id} value={l.id}>
-                      {l.name}
+                  {uniqueWarehouses.map((w) => (
+                    <SelectItem key={w.id} value={w.id}>
+                      {w.name}
                     </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
             </div>
             <div className="space-y-2">
-              <Label>To Location</Label>
-              <Select value={editForm.to_location_id} onValueChange={(v) => setEditForm({ ...editForm, to_location_id: v })}>
+              <Label>To Warehouse</Label>
+              <Select value={editForm.to_warehouse_id} onValueChange={(v) => setEditForm({ ...editForm, to_warehouse_id: v })}>
                 <SelectTrigger>
                   <SelectValue placeholder="Select destination" />
                 </SelectTrigger>
                 <SelectContent>
-                  {uniqueLocations.map((l) => (
-                    <SelectItem key={l.id} value={l.id}>
-                      {l.name}
+                  {uniqueWarehouses.map((w) => (
+                    <SelectItem key={w.id} value={w.id}>
+                      {w.name}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/supabase/migrations/20250922093000_inventory_transfers_warehouses.sql
+++ b/supabase/migrations/20250922093000_inventory_transfers_warehouses.sql
@@ -1,0 +1,104 @@
+-- Enforce inventory transfers to be between warehouses
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_schema = 'public' AND table_name = 'inventory_transfers' AND column_name = 'from_warehouse_id'
+  ) THEN
+    ALTER TABLE public.inventory_transfers ADD COLUMN from_warehouse_id uuid NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_schema = 'public' AND table_name = 'inventory_transfers' AND column_name = 'to_warehouse_id'
+  ) THEN
+    ALTER TABLE public.inventory_transfers ADD COLUMN to_warehouse_id uuid NULL;
+  END IF;
+END $$;
+
+-- Foreign keys to warehouses if the table exists
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables 
+    WHERE table_schema = 'public' AND table_name = 'warehouses'
+  ) THEN
+    ALTER TABLE public.inventory_transfers
+      DROP CONSTRAINT IF EXISTS inventory_transfers_from_warehouse_id_fkey;
+    ALTER TABLE public.inventory_transfers
+      ADD CONSTRAINT inventory_transfers_from_warehouse_id_fkey
+        FOREIGN KEY (from_warehouse_id) REFERENCES public.warehouses(id) ON DELETE CASCADE;
+
+    ALTER TABLE public.inventory_transfers
+      DROP CONSTRAINT IF EXISTS inventory_transfers_to_warehouse_id_fkey;
+    ALTER TABLE public.inventory_transfers
+      ADD CONSTRAINT inventory_transfers_to_warehouse_id_fkey
+        FOREIGN KEY (to_warehouse_id) REFERENCES public.warehouses(id) ON DELETE CASCADE;
+  END IF;
+END $$;
+
+-- Make legacy location columns nullable to allow warehouse-only records
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_schema = 'public' AND table_name = 'inventory_transfers' AND column_name = 'from_location_id' AND is_nullable = 'NO'
+  ) THEN
+    ALTER TABLE public.inventory_transfers ALTER COLUMN from_location_id DROP NOT NULL;
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_schema = 'public' AND table_name = 'inventory_transfers' AND column_name = 'to_location_id' AND is_nullable = 'NO'
+  ) THEN
+    ALTER TABLE public.inventory_transfers ALTER COLUMN to_location_id DROP NOT NULL;
+  END IF;
+END $$;
+
+-- Optional backfill from business_locations.default_warehouse_id when present
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'business_locations' AND column_name = 'default_warehouse_id'
+  ) THEN
+    UPDATE public.inventory_transfers t
+    SET from_warehouse_id = COALESCE(t.from_warehouse_id, bl_from.default_warehouse_id)
+    FROM public.business_locations bl_from
+    WHERE t.from_location_id = bl_from.id AND t.from_warehouse_id IS NULL;
+
+    UPDATE public.inventory_transfers t
+    SET to_warehouse_id = COALESCE(t.to_warehouse_id, bl_to.default_warehouse_id)
+    FROM public.business_locations bl_to
+    WHERE t.to_location_id = bl_to.id AND t.to_warehouse_id IS NULL;
+  END IF;
+END $$;
+
+-- Null out legacy location columns after backfill so that warehouses are authoritative
+UPDATE public.inventory_transfers SET from_location_id = NULL WHERE from_warehouse_id IS NOT NULL;
+UPDATE public.inventory_transfers SET to_location_id = NULL WHERE to_warehouse_id IS NOT NULL;
+
+-- Add a CHECK constraint to enforce warehouse-only going forward
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_schema = 'public' AND table_name = 'inventory_transfers' AND constraint_name = 'inventory_transfers_warehouse_only_chk'
+  ) THEN
+    ALTER TABLE public.inventory_transfers
+      ADD CONSTRAINT inventory_transfers_warehouse_only_chk
+      CHECK (
+        from_warehouse_id IS NOT NULL AND to_warehouse_id IS NOT NULL
+        AND from_location_id IS NULL AND to_location_id IS NULL
+      ) NOT VALID;
+    -- Attempt to validate; if it fails, old rows remain unvalidated but new rows must satisfy the constraint
+    BEGIN
+      ALTER TABLE public.inventory_transfers VALIDATE CONSTRAINT inventory_transfers_warehouse_only_chk;
+    EXCEPTION WHEN others THEN
+      -- Ignore validation errors for legacy data
+      NULL;
+    END;
+  END IF;
+END $$;
+
+-- Indexes for faster lookups
+CREATE INDEX IF NOT EXISTS idx_inventory_transfers_from_wh ON public.inventory_transfers(from_warehouse_id);
+CREATE INDEX IF NOT EXISTS idx_inventory_transfers_to_wh ON public.inventory_transfers(to_warehouse_id);
+
+-- Note: We intentionally keep location columns for backward compatibility.
+-- New writes should populate warehouse columns only.
+


### PR DESCRIPTION
Migrate stock transfers to use warehouses instead of locations to align with business requirements.

The user explicitly stated: "Stock transfers should only happen between Warehouses. Source warehouse to Destination Warehouse." This PR implements that by introducing `from_warehouse_id` and `to_warehouse_id` columns, updating the UI, and adding database constraints to enforce this new model while maintaining backward compatibility for existing data.

---
<a href="https://cursor.com/background-agent?bcId=bc-dac371fe-ae90-4dc8-addd-b5e9bcae9d8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dac371fe-ae90-4dc8-addd-b5e9bcae9d8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

