### PR TITLE
Restore POS button to top bar

### DIFF
--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useEffect } from 'react';
-import { Bell, User, Search, Menu, ChevronDown, Settings, LogOut, Plus, Building2 } from 'lucide-react';
+import { Bell, User, Search, Menu, ChevronDown, Settings, LogOut, Plus, Building2, CreditCard } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -122,6 +122,10 @@ export const Topbar: React.FC<TopbarProps> = ({ onMenuClick }) => {
         {/* Right side */}
         <div className="flex items-center gap-4">
           <ThemeToggle />
+          <Button onClick={() => navigate('/pos')} className="hidden sm:inline-flex gap-2">
+            <CreditCard className="h-4 w-4" />
+            POS
+          </Button>
           {/* Organization Switcher */}
           {organizations.length > 1 && (
             <DropdownMenu>


### PR DESCRIPTION
Re-adds the POS button to the top bar, navigating to `/pos` with a credit card icon.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d70de11-b062-4864-877a-8adc45ca2236">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7d70de11-b062-4864-877a-8adc45ca2236">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

