### PR TITLE
Consolidate organization user buttons into dropdown

### DIFF
--- a/web/src/components/ActionsDropdown.tsx
+++ b/web/src/components/ActionsDropdown.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useRef, useState } from 'react'
+
+export interface DropdownAction {
+  label: string
+  onSelect: () => void
+  destructive?: boolean
+  disabled?: boolean
+}
+
+interface ActionsDropdownProps {
+  buttonLabel?: string
+  actions: DropdownAction[]
+  align?: 'start' | 'end'
+}
+
+export default function ActionsDropdown({ buttonLabel = 'Actions', actions, align = 'end' }: ActionsDropdownProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const buttonRef = useRef<HTMLButtonElement | null>(null)
+  const menuRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (!isOpen) return
+      const target = event.target as Node
+      if (menuRef.current && !menuRef.current.contains(target) && buttonRef.current && !buttonRef.current.contains(target)) {
+        setIsOpen(false)
+      }
+    }
+    function handleEsc(event: KeyboardEvent) {
+      if (event.key === 'Escape') setIsOpen(false)
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('keydown', handleEsc)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('keydown', handleEsc)
+    }
+  }, [isOpen])
+
+  function handleToggle() {
+    setIsOpen((prev) => !prev)
+  }
+
+  function onActionClick(action: DropdownAction) {
+    if (action.disabled) return
+    action.onSelect()
+    setIsOpen(false)
+  }
+
+  return (
+    <div className="dropdown" style={{ position: 'relative', display: 'inline-block' }}>
+      <button
+        ref={buttonRef}
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        onClick={handleToggle}
+        className="dropdown__trigger"
+      >
+        {buttonLabel}
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" style={{ marginLeft: 8 }} aria-hidden>
+          <path d="M7 10l5 5 5-5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
+      </button>
+      {isOpen && (
+        <div
+          ref={menuRef}
+          role="menu"
+          className="dropdown__menu"
+          style={{
+            position: 'absolute',
+            minWidth: 180,
+            zIndex: 20,
+            marginTop: 6,
+            right: align === 'end' ? 0 : 'auto',
+            left: align === 'start' ? 0 : 'auto',
+            backgroundColor: 'var(--color-surface)',
+            border: '1px solid var(--color-border)',
+            borderRadius: 8,
+            padding: 6,
+            boxShadow: '0 6px 24px rgba(0,0,0,0.24)'
+          }}
+        >
+          {actions.map((action, index) => (
+            <button
+              key={index}
+              role="menuitem"
+              type="button"
+              disabled={action.disabled}
+              onClick={() => onActionClick(action)}
+              className={`dropdown__item${action.destructive ? ' dropdown__item--destructive' : ''}`}
+              style={{
+                display: 'flex',
+                width: '100%',
+                textAlign: 'left',
+                padding: '8px 10px',
+                borderRadius: 6,
+                border: '1px solid transparent',
+                background: 'transparent',
+                color: action.destructive ? '#ef4444' : 'inherit',
+                opacity: action.disabled ? 0.5 : 1,
+                cursor: action.disabled ? 'not-allowed' : 'pointer'
+              }}
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/web/src/pages/UsersTable.tsx
+++ b/web/src/pages/UsersTable.tsx
@@ -1,0 +1,115 @@
+import { useMemo, useState } from 'react'
+import ActionsDropdown, { DropdownAction } from '../components/ActionsDropdown'
+
+export interface OrganizationUser {
+  id: string
+  name: string
+  email: string
+  role: 'Owner' | 'Admin' | 'Member'
+  status: 'Active' | 'Invited' | 'Suspended'
+}
+
+const SAMPLE_USERS: OrganizationUser[] = [
+  { id: 'u_1', name: 'Alice Johnson', email: 'alice@example.com', role: 'Owner', status: 'Active' },
+  { id: 'u_2', name: 'Bob Smith', email: 'bob@example.com', role: 'Admin', status: 'Invited' },
+  { id: 'u_3', name: 'Carol Davis', email: 'carol@example.com', role: 'Member', status: 'Active' },
+  { id: 'u_4', name: 'Diego Lee', email: 'diego@example.com', role: 'Member', status: 'Suspended' },
+]
+
+export default function UsersTable() {
+  const [users, setUsers] = useState<OrganizationUser[]>(SAMPLE_USERS)
+
+  function updateUser(id: string, updater: (u: OrganizationUser) => OrganizationUser) {
+    setUsers((prev) => prev.map((u) => (u.id === id ? updater(u) : u)))
+  }
+
+  function removeUser(id: string) {
+    setUsers((prev) => prev.filter((u) => u.id !== id))
+  }
+
+  function buildActionsForUser(user: OrganizationUser): DropdownAction[] {
+    const actions: DropdownAction[] = []
+
+    if (user.status !== 'Suspended') {
+      actions.push({
+        label: 'Suspend user',
+        destructive: true,
+        onSelect: () => updateUser(user.id, (u) => ({ ...u, status: 'Suspended' })),
+      })
+    } else {
+      actions.push({
+        label: 'Unsuspend user',
+        onSelect: () => updateUser(user.id, (u) => ({ ...u, status: 'Active' })),
+      })
+    }
+
+    actions.push({
+      label: 'Reset password',
+      onSelect: () => window.alert(`Password reset email sent to ${user.email}`),
+    })
+
+    if (user.role !== 'Owner') {
+      actions.push({
+        label: 'Promote to Admin',
+        onSelect: () => updateUser(user.id, (u) => ({ ...u, role: 'Admin' })),
+      })
+    }
+
+    actions.push({
+      label: 'Remove from organization',
+      destructive: true,
+      onSelect: () => removeUser(user.id),
+    })
+
+    return actions
+  }
+
+  const tableRows = useMemo(() => users.map((user) => {
+    const actions = buildActionsForUser(user)
+    return (
+      <tr key={user.id}>
+        <td>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <span style={{ fontWeight: 700 }}>{user.name}</span>
+            <span style={{ color: 'var(--color-muted)', fontSize: 13 }}>{user.email}</span>
+          </div>
+        </td>
+        <td>{user.role}</td>
+        <td>{user.status}</td>
+        <td style={{ textAlign: 'right' }}>
+          <ActionsDropdown actions={actions} />
+        </td>
+      </tr>
+    )
+  }), [users])
+
+  return (
+    <div style={{ width: '100%', maxWidth: 960, margin: '0 auto', padding: 24 }}>
+      <h2 style={{ margin: '0 0 12px' }}>Organization Users</h2>
+      <p style={{ margin: '0 0 20px', color: 'var(--color-muted)' }}>
+        Manage members of this organization. All per-row actions have been consolidated under a single Actions button.
+      </p>
+      <div style={{
+        border: '1px solid var(--color-border)',
+        borderRadius: 12,
+        overflow: 'hidden',
+        background: 'var(--color-surface)'
+      }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <thead>
+            <tr style={{ background: 'var(--color-surface-2)' }}>
+              <th style={{ textAlign: 'left', padding: '12px 16px', fontWeight: 700 }}>User</th>
+              <th style={{ textAlign: 'left', padding: '12px 16px', fontWeight: 700 }}>Role</th>
+              <th style={{ textAlign: 'left', padding: '12px 16px', fontWeight: 700 }}>Status</th>
+              <th style={{ textAlign: 'right', padding: '12px 16px', fontWeight: 700 }}>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {tableRows}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+

--- a/workspace/web/src/App.tsx
+++ b/workspace/web/src/App.tsx
@@ -1,32 +1,10 @@
-import { useState } from 'react'
 import './App.css'
-import reactLogo from './assets/react.svg'
+import UsersTable from './pages/UsersTable'
 
 export default function App() {
-	const [count, setCount] = useState(0)
-
 	return (
-		<div style={{ display: 'grid', placeItems: 'center', padding: '2rem' }}>
-			<div>
-				<a href="https://vite.dev" target="_blank" rel="noreferrer">
-					<img src="/vite.svg" className="logo" alt="Vite logo" />
-				</a>
-				<a href="https://react.dev" target="_blank" rel="noreferrer">
-					<img src={reactLogo} className="logo react" alt="React logo" />
-				</a>
-			</div>
-			<h1>Vite + React</h1>
-			<div className="card">
-				<button onClick={() => setCount((count) => count + 1)}>
-					count is {count}
-				</button>
-				<p>
-					Edit <code>src/App.tsx</code> and save to test HMR
-				</p>
-			</div>
-			<p className="read-the-docs">
-				Click on the Vite and React logos to learn more
-			</p>
+		<div style={{ padding: '2rem' }}>
+			<UsersTable />
 		</div>
 	)
 }


### PR DESCRIPTION
Adds an `ActionsDropdown` component and a `UsersTable` page to demonstrate consolidating multiple per-row actions into a single dropdown.

---
<a href="https://cursor.com/background-agent?bcId=bc-632321c6-52cc-441e-9920-c2d6155bf7d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-632321c6-52cc-441e-9920-c2d6155bf7d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

