### PR TITLE
Fix formatUsdCents type error

### DIFF
--- a/src/lib/saas/hooks.ts
+++ b/src/lib/saas/hooks.ts
@@ -301,10 +301,24 @@ export const useOrganizationCurrency = () => {
     [currency.code]
   )
 
+  // Backward-compatible helpers used across the app
+  const formatUsdCents = useCallback(
+    (cents: number): string => {
+      const safeCents = Number.isFinite(cents as any) ? (cents as number) : 0
+      return formatAmount(safeCents / 100)
+    },
+    [formatAmount]
+  )
+
   return {
     currency,
     loading,
+    // Modern API
     formatAmount,
+    // Common consumers expect these
+    symbol: currency.symbol,
+    format: formatAmount,
+    formatUsdCents,
   }
 }
 


### PR DESCRIPTION
Add backward-compatible currency formatting helpers to `useOrganizationCurrency` to fix `TypeError`.

The `TypeError: formatUsdCents is not a function` occurred because `AdminSubscriptionPlans` and other components were calling `formatUsdCents`, `format`, and `symbol` from the `useOrganizationCurrency` hook, but these functions/properties were not exposed by the hook. This PR adds them back to ensure existing usages continue to work without errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-01638cbf-6bfc-419b-8955-502def597a4a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01638cbf-6bfc-419b-8955-502def597a4a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

