### PR TITLE
Debug react error 31

### DIFF
--- a/src/lib/saas/hooks.ts
+++ b/src/lib/saas/hooks.ts
@@ -328,10 +328,10 @@ export const useOrganizationCurrency = () => {
 export const useOrganizationTaxRate = () => {
   const { organization } = useSaas()
   
-  return {
-    taxRate: 0.1, // 10% default
-    loading: false,
-  }
+  // Return percentage as a number for easier downstream math
+  // e.g., 8.5 means 8.5%
+  const percent = 10 // default 10%
+  return percent
 }
 
 /**


### PR DESCRIPTION
Change `useOrganizationTaxRate` to return a number instead of an object to fix React error #31.

The hook was returning an object `{ taxRate, loading }`, which was sometimes rendered directly in JSX, causing React's "Objects are not valid as a React child" error. Returning a numeric percentage resolves this, aligning with how the value was already being consumed.

---
<a href="https://cursor.com/background-agent?bcId=bc-19b42dc2-b7cb-4ff2-8b30-327023f64dd2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-19b42dc2-b7cb-4ff2-8b30-327023f64dd2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

