### PR TITLE
Update metrics card colors to match profile page

### DIFF
--- a/src/pages/Clients.tsx
+++ b/src/pages/Clients.tsx
@@ -762,85 +762,79 @@ export default function Clients() {
 
       {/* Enhanced Statistics Grid */}
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6">
-        <Card className="relative overflow-hidden border-0 shadow-lg hover:shadow-xl transition-all duration-300">
-          <div className="absolute inset-0 bg-gradient-to-br from-blue-500 to-blue-600 opacity-100" />
-          <CardHeader className="relative flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-white/90">Total Clients</CardTitle>
-            <Users className="h-4 w-4 text-white/80" />
+        <Card className="bg-gradient-to-br from-blue-50 to-sky-50 border-blue-200">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium text-blue-700">Total Clients</CardTitle>
+            <Users className="h-4 w-4 text-blue-600" />
           </CardHeader>
-          <CardContent className="relative">
-            <div className="text-2xl font-bold text-white">{stats.total}</div>
-            <p className="text-xs text-white/80">
+          <CardContent>
+            <div className="text-2xl font-bold text-blue-700">{stats.total}</div>
+            <p className="text-xs text-blue-600">
               {stats.active} active
             </p>
           </CardContent>
         </Card>
 
-        <Card className="relative overflow-hidden border-0 shadow-lg hover:shadow-xl transition-all duration-300">
-          <div className="absolute inset-0 bg-gradient-to-br from-emerald-500 to-emerald-600 opacity-100" />
-          <CardHeader className="relative flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-white/90">Total Revenue</CardTitle>
-            <DollarSign className="h-4 w-4 text-white/80" />
+        <Card className="bg-gradient-to-br from-green-50 to-emerald-50 border-green-200">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium text-green-700">Total Revenue</CardTitle>
+            <DollarSign className="h-4 w-4 text-green-600" />
           </CardHeader>
-          <CardContent className="relative">
-            <div className="text-2xl font-bold text-white">{formatMoney(stats.totalRevenue)}</div>
-            <p className="text-xs text-white/80">
+          <CardContent>
+            <div className="text-2xl font-bold text-green-700">{formatMoney(stats.totalRevenue)}</div>
+            <p className="text-xs text-green-600">
               From all clients
             </p>
           </CardContent>
         </Card>
 
-        <Card className="relative overflow-hidden border-0 shadow-lg hover:shadow-xl transition-all duration-300">
-          <div className="absolute inset-0 bg-gradient-to-br from-violet-500 to-violet-600 opacity-100" />
-          <CardHeader className="relative flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-white/90">Avg Spent</CardTitle>
-            <Target className="h-4 w-4 text-white/80" />
+        <Card className="bg-gradient-to-br from-purple-50 to-violet-50 border-purple-200">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium text-purple-700">Avg Spent</CardTitle>
+            <Target className="h-4 w-4 text-purple-600" />
           </CardHeader>
-          <CardContent className="relative">
-            <div className="text-2xl font-bold text-white">{formatMoney(stats.averageSpent)}</div>
-            <p className="text-xs text-white/80">
+          <CardContent>
+            <div className="text-2xl font-bold text-purple-700">{formatMoney(stats.averageSpent)}</div>
+            <p className="text-xs text-purple-600">
               Per client
             </p>
           </CardContent>
         </Card>
 
-        <Card className="relative overflow-hidden border-0 shadow-lg hover:shadow-xl transition-all duration-300">
-          <div className="absolute inset-0 bg-gradient-to-br from-amber-500 to-amber-600 opacity-100" />
-          <CardHeader className="relative flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-white/90">VIP Clients</CardTitle>
-            <Crown className="h-4 w-4 text-white/80" />
+        <Card className="bg-gradient-to-br from-orange-50 to-amber-50 border-orange-200">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium text-orange-700">VIP Clients</CardTitle>
+            <Crown className="h-4 w-4 text-orange-600" />
           </CardHeader>
-          <CardContent className="relative">
-            <div className="text-2xl font-bold text-white">{stats.vip}</div>
-            <p className="text-xs text-white/80">
+          <CardContent>
+            <div className="text-2xl font-bold text-orange-700">{stats.vip}</div>
+            <p className="text-xs text-orange-600">
               Premium members
             </p>
           </CardContent>
         </Card>
 
-        <Card className="relative overflow-hidden border-0 shadow-lg hover:shadow-xl transition-all duration-300">
-          <div className="absolute inset-0 bg-gradient-to-br from-pink-500 to-pink-600 opacity-100" />
-          <CardHeader className="relative flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-white/90">New This Month</CardTitle>
-            <UserPlus className="h-4 w-4 text-white/80" />
+        <Card className="bg-gradient-to-br from-pink-50 to-rose-50 border-pink-200">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium text-pink-700">New This Month</CardTitle>
+            <UserPlus className="h-4 w-4 text-pink-600" />
           </CardHeader>
-          <CardContent className="relative">
-            <div className="text-2xl font-bold text-white">{stats.newThisMonth}</div>
-            <p className="text-xs text-white/80">
+          <CardContent>
+            <div className="text-2xl font-bold text-pink-700">{stats.newThisMonth}</div>
+            <p className="text-xs text-pink-600">
               Fresh faces
             </p>
           </CardContent>
         </Card>
 
-        <Card className="relative overflow-hidden border-0 shadow-lg hover:shadow-xl transition-all duration-300">
-          <div className="absolute inset-0 bg-gradient-to-br from-cyan-500 to-cyan-600 opacity-100" />
-          <CardHeader className="relative flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-white/90">Retention Rate</CardTitle>
-            <Heart className="h-4 w-4 text-white/80" />
+        <Card className="bg-gradient-to-br from-cyan-50 to-sky-50 border-cyan-200">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium text-cyan-700">Retention Rate</CardTitle>
+            <Heart className="h-4 w-4 text-cyan-600" />
           </CardHeader>
-          <CardContent className="relative">
-            <div className="text-2xl font-bold text-white">{stats.retentionRate.toFixed(1)}%</div>
-            <p className="text-xs text-white/80">
+          <CardContent>
+            <div className="text-2xl font-bold text-cyan-700">{stats.retentionRate.toFixed(1)}%</div>
+            <p className="text-xs text-cyan-600">
               Return clients
             </p>
           </CardContent>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -314,7 +314,10 @@ const Dashboard = () => {
       previousValue: metrics.revenueYesterday,
       change: safePercent(metrics.revenueToday, metrics.revenueYesterday),
       icon: DollarSign,
-      gradient: "from-emerald-500 to-emerald-600",
+      textColor: "text-green-700",
+      valueColor: "text-green-700",
+      subtextColor: "text-green-600",
+      iconColor: "text-green-600",
       trend: metrics.revenueToday >= metrics.revenueYesterday ? "up" : "down"
     },
     {
@@ -323,7 +326,10 @@ const Dashboard = () => {
       previousValue: metrics.appointmentsYesterday,
       change: safePercent(metrics.appointmentsToday, metrics.appointmentsYesterday),
       icon: Calendar,
-      gradient: "from-blue-500 to-blue-600",
+      textColor: "text-blue-700",
+      valueColor: "text-blue-700",
+      subtextColor: "text-blue-600",
+      iconColor: "text-blue-600",
       trend: metrics.appointmentsToday >= metrics.appointmentsYesterday ? "up" : "down"
     },
     {
@@ -332,7 +338,10 @@ const Dashboard = () => {
       previousValue: metrics.newClientsYesterday,
       change: safePercent(metrics.newClientsToday, metrics.newClientsYesterday),
       icon: Users,
-      gradient: "from-purple-500 to-purple-600",
+      textColor: "text-purple-700",
+      valueColor: "text-purple-700",
+      subtextColor: "text-purple-600",
+      iconColor: "text-purple-600",
       trend: metrics.newClientsToday >= metrics.newClientsYesterday ? "up" : "down"
     },
     {
@@ -341,7 +350,10 @@ const Dashboard = () => {
       previousValue: metrics.staffUtilizationYesterday,
       change: safePercent(metrics.staffUtilizationToday, metrics.staffUtilizationYesterday),
       icon: TrendingUp,
-      gradient: "from-amber-500 to-amber-600",
+      textColor: "text-orange-700",
+      valueColor: "text-orange-700",
+      subtextColor: "text-orange-600",
+      iconColor: "text-orange-600",
       trend: metrics.staffUtilizationToday >= metrics.staffUtilizationYesterday ? "up" : "down"
     },
     {
@@ -350,7 +362,10 @@ const Dashboard = () => {
       previousValue: metrics.completionRateYesterday,
       change: safePercent(metrics.completionRateToday, metrics.completionRateYesterday),
       icon: CheckCircle,
-      gradient: "from-green-500 to-green-600",
+      textColor: "text-green-700",
+      valueColor: "text-green-700",
+      subtextColor: "text-green-600",
+      iconColor: "text-green-600",
       trend: metrics.completionRateToday >= metrics.completionRateYesterday ? "up" : "down"
     },
     {
@@ -359,7 +374,10 @@ const Dashboard = () => {
       previousValue: metrics.avgServiceTimeYesterday,
       change: safePercent(metrics.avgServiceTimeToday, metrics.avgServiceTimeYesterday),
       icon: Timer,
-      gradient: "from-cyan-500 to-cyan-600",
+      textColor: "text-cyan-700",
+      valueColor: "text-cyan-700",
+      subtextColor: "text-cyan-600",
+      iconColor: "text-cyan-600",
       trend: metrics.avgServiceTimeToday <= metrics.avgServiceTimeYesterday ? "up" : "down"
     }
   ];
@@ -559,23 +577,22 @@ const Dashboard = () => {
       {/* Enhanced Statistics Grid */}
       <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
         {todayStats.map((stat, index) => (
-          <Card key={index} className="relative overflow-hidden border-0 shadow-lg hover:shadow-xl transition-all duration-300">
-            <div className={`absolute inset-0 bg-gradient-to-br ${stat.gradient} opacity-100`} />
-            <CardHeader className="relative flex flex-row items-center justify-between space-y-0 p-3 sm:p-4 pb-2">
-              <CardTitle className="text-sm font-medium text-white/90">
+          <Card key={index} className={`${stat.bgClass}`}>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 p-3 sm:p-4 pb-2">
+              <CardTitle className={`text-sm font-medium ${stat.textColor}`}>
                 {stat.title}
               </CardTitle>
-              <stat.icon className="h-4 w-4 text-white/80" />
+              <stat.icon className={`h-4 w-4 ${stat.iconColor}`} />
             </CardHeader>
-            <CardContent className="relative p-3 sm:p-4">
-              <div className="text-xl sm:text-2xl font-bold text-white">{stat.value}</div>
+            <CardContent className="p-3 sm:p-4">
+              <div className={`text-xl sm:text-2xl font-bold ${stat.valueColor}`}>{stat.value}</div>
               <div className="flex items-center mt-1">
                 {stat.change > 0 ? (
-                  <ArrowUpRight className="h-3 w-3 text-white/80 mr-1" />
+                  <ArrowUpRight className={`h-3 w-3 ${stat.iconColor} mr-1`} />
                 ) : (
-                  <ArrowDownRight className="h-3 w-3 text-white/80 mr-1" />
+                  <ArrowDownRight className={`h-3 w-3 ${stat.iconColor} mr-1`} />
                 )}
-                <p className="text-xs text-white/80">
+                <p className={`text-xs ${stat.subtextColor}`}>
                   {stat.change > 0 ? '+' : ''}{stat.change.toFixed(1)}% from yesterday
                 </p>
               </div>

--- a/src/pages/Inventory.tsx
+++ b/src/pages/Inventory.tsx
@@ -1327,36 +1327,33 @@ export default function Inventory() {
 
       {/* Metrics Dashboard */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        <Card className="relative overflow-hidden border-0 shadow-lg">
-          <div className="absolute inset-0 bg-gradient-to-br from-emerald-500 to-emerald-600 opacity-95" />
-          <CardHeader className="relative pb-2">
-            <CardTitle className="text-sm font-medium text-white/90">Cost Value</CardTitle>
+        <Card className="bg-gradient-to-br from-green-50 to-emerald-50 border-green-200">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-green-700">Cost Value</CardTitle>
           </CardHeader>
-          <CardContent className="relative">
-            <div className="text-2xl font-bold text-white">{formatMoney(totals.totalCost)}</div>
-            <p className="text-xs text-white/80">Stock at cost</p>
+          <CardContent>
+            <div className="text-2xl font-bold text-green-700">{formatMoney(totals.totalCost)}</div>
+            <p className="text-xs text-green-600">Stock at cost</p>
           </CardContent>
         </Card>
 
-        <Card className="relative overflow-hidden border-0 shadow-lg">
-          <div className="absolute inset-0 bg-gradient-to-br from-indigo-500 to-indigo-600 opacity-95" />
-          <CardHeader className="relative pb-2">
-            <CardTitle className="text-sm font-medium text-white/90">Sales Value</CardTitle>
+        <Card className="bg-gradient-to-br from-indigo-50 to-blue-100 border-indigo-200">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-indigo-700">Sales Value</CardTitle>
           </CardHeader>
-          <CardContent className="relative">
-            <div className="text-2xl font-bold text-white">{formatMoney(totals.totalSales)}</div>
-            <p className="text-xs text-white/80">Stock at selling price</p>
+          <CardContent>
+            <div className="text-2xl font-bold text-indigo-700">{formatMoney(totals.totalSales)}</div>
+            <p className="text-xs text-indigo-600">Stock at selling price</p>
           </CardContent>
         </Card>
 
-        <Card className="relative overflow-hidden border-0 shadow-lg">
-          <div className="absolute inset-0 bg-gradient-to-br from-amber-500 to-amber-600 opacity-95" />
-          <CardHeader className="relative pb-2">
-            <CardTitle className="text-sm font-medium text-white/90">Quantities in Stock</CardTitle>
+        <Card className="bg-gradient-to-br from-orange-50 to-amber-50 border-orange-200">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-orange-700">Quantities in Stock</CardTitle>
           </CardHeader>
-          <CardContent className="relative">
-            <div className="text-2xl font-bold text-white">{formatRegionalNumber(totals.totalQty)}</div>
-            <p className="text-xs text-white/80">All products</p>
+          <CardContent>
+            <div className="text-2xl font-bold text-orange-700">{formatRegionalNumber(totals.totalQty)}</div>
+            <p className="text-xs text-orange-600">All products</p>
           </CardContent>
         </Card>
       </div>

--- a/src/pages/InvoiceCreate.tsx
+++ b/src/pages/InvoiceCreate.tsx
@@ -415,9 +415,9 @@ export default function InvoiceCreate() {
             <Receipt className="w-4 h-4 text-green-600" />
             Invoice Items
           </h3>
-          <Card className="bg-slate-500/10 border-slate-200">
+          <Card className="bg-gradient-to-br from-purple-50 to-pink-50 border-purple-200">
             <CardHeader className="pb-3">
-              <CardTitle className="text-sm">Add Item</CardTitle>
+              <CardTitle className="text-sm text-purple-800">Add Item</CardTitle>
             </CardHeader>
             <CardContent>
               <div className="grid grid-cols-1 lg:grid-cols-7 gap-3">

--- a/src/pages/InvoiceEdit.tsx
+++ b/src/pages/InvoiceEdit.tsx
@@ -314,9 +314,9 @@ export default function InvoiceEdit() {
             <Receipt className="w-4 h-4 text-green-600" />
             Invoice Items
           </h3>
-          <Card className="bg-slate-500/10 border-slate-200">
+          <Card className="bg-gradient-to-br from-purple-50 to-pink-50 border-purple-200">
             <CardHeader className="pb-3">
-              <CardTitle className="text-sm">Add Item</CardTitle>
+              <CardTitle className="text-sm text-purple-800">Add Item</CardTitle>
             </CardHeader>
             <CardContent>
               <div className="grid grid-cols-1 lg:grid-cols-7 gap-3">

--- a/src/pages/Invoices.tsx
+++ b/src/pages/Invoices.tsx
@@ -619,53 +619,53 @@ export default function Invoices() {
 
       {/* Statistics Grid */}
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        <Card className="bg-gradient-to-br from-blue-500 to-blue-600 text-white border-0 shadow-lg">
+        <Card className="bg-gradient-to-br from-blue-50 to-sky-50 border-blue-200">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium opacity-90">Total Invoices</CardTitle>
-            <Receipt className="h-4 w-4 opacity-80" />
+            <CardTitle className="text-sm font-medium text-blue-700">Total Invoices</CardTitle>
+            <Receipt className="h-4 w-4 text-blue-600" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{totalInvoices}</div>
-            <p className="text-xs opacity-80">
+            <div className="text-2xl font-bold text-blue-700">{totalInvoices}</div>
+            <p className="text-xs text-blue-600">
               {draftInvoices} drafts, {paidInvoices} paid
             </p>
           </CardContent>
         </Card>
 
-        <Card className="bg-gradient-to-br from-emerald-500 to-emerald-600 text-white border-0 shadow-lg">
+        <Card className="bg-gradient-to-br from-green-50 to-emerald-50 border-green-200">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium opacity-90">Total Revenue</CardTitle>
-            <DollarSign className="h-4 w-4 opacity-80" />
+            <CardTitle className="text-sm font-medium text-green-700">Total Revenue</CardTitle>
+            <DollarSign className="h-4 w-4 text-green-600" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{formatMoney(totalRevenue, { decimals: 0 })}</div>
-            <p className="text-xs opacity-80">
+            <div className="text-2xl font-bold text-green-700">{formatMoney(totalRevenue, { decimals: 0 })}</div>
+            <p className="text-xs text-green-600">
               From {paidInvoices} paid invoices
             </p>
           </CardContent>
         </Card>
 
-        <Card className="bg-gradient-to-br from-amber-500 to-amber-600 text-white border-0 shadow-lg">
+        <Card className="bg-gradient-to-br from-orange-50 to-amber-50 border-orange-200">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium opacity-90">Pending Amount</CardTitle>
-            <Clock className="h-4 w-4 opacity-80" />
+            <CardTitle className="text-sm font-medium text-orange-700">Pending Amount</CardTitle>
+            <Clock className="h-4 w-4 text-orange-600" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{formatMoney(pendingRevenue, { decimals: 0 })}</div>
-            <p className="text-xs opacity-80">
+            <div className="text-2xl font-bold text-orange-700">{formatMoney(pendingRevenue, { decimals: 0 })}</div>
+            <p className="text-xs text-orange-600">
               {pendingInvoices + overdueInvoices} pending
             </p>
           </CardContent>
         </Card>
 
-        <Card className="bg-gradient-to-br from-violet-500 to-violet-600 text-white border-0 shadow-lg">
+        <Card className="bg-gradient-to-br from-purple-50 to-violet-50 border-purple-200">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium opacity-90">Collection Rate</CardTitle>
-            <Target className="h-4 w-4 opacity-80" />
+            <CardTitle className="text-sm font-medium text-purple-700">Collection Rate</CardTitle>
+            <Target className="h-4 w-4 text-purple-600" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{collectionRate.toFixed(1)}%</div>
-            <p className="text-xs opacity-80">
+            <div className="text-2xl font-bold text-purple-700">{collectionRate.toFixed(1)}%</div>
+            <p className="text-xs text-purple-600">
               Avg: {formatMoney(Number(averageInvoiceValue.toFixed(0)), { decimals: 0 })}
             </p>
           </CardContent>

--- a/src/pages/JobCards.tsx
+++ b/src/pages/JobCards.tsx
@@ -1108,85 +1108,79 @@ export default function JobCards() {
 
       {/* Enhanced Statistics Grid */}
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
-        <Card className="relative overflow-hidden border-0 shadow-lg hover:shadow-xl transition-all duration-300">
-          <div className="absolute inset-0 bg-gradient-to-br from-blue-500 to-blue-600 opacity-100" />
-          <CardHeader className="relative flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-white/90">Total Job Cards</CardTitle>
-            <FileText className="h-4 w-4 text-white/80" />
+        <Card className="bg-gradient-to-br from-blue-50 to-sky-50 border-blue-200">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium text-blue-700">Total Job Cards</CardTitle>
+            <FileText className="h-4 w-4 text-blue-600" />
           </CardHeader>
-          <CardContent className="relative">
-            <div className="text-2xl font-bold text-white">{stats.total}</div>
-            <p className="text-xs text-white/80">
+          <CardContent>
+            <div className="text-2xl font-bold text-blue-700">{stats.total}</div>
+            <p className="text-xs text-blue-600">
               {stats.todayCards} created today
             </p>
           </CardContent>
         </Card>
 
-        <Card className="relative overflow-hidden border-0 shadow-lg hover:shadow-xl transition-all duration-300">
-          <div className="absolute inset-0 bg-gradient-to-br from-emerald-500 to-emerald-600 opacity-100" />
-          <CardHeader className="relative flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-white/90">Completed</CardTitle>
-            <CheckCircle className="h-4 w-4 text-white/80" />
+        <Card className="bg-gradient-to-br from-green-50 to-emerald-50 border-green-200">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium text-green-700">Completed</CardTitle>
+            <CheckCircle className="h-4 w-4 text-green-600" />
           </CardHeader>
-          <CardContent className="relative">
-            <div className="text-2xl font-bold text-white">{stats.completed}</div>
-            <p className="text-xs text-white/80">
+          <CardContent>
+            <div className="text-2xl font-bold text-green-700">{stats.completed}</div>
+            <p className="text-xs text-green-600">
               {stats.completionRate.toFixed(1)}% success rate
             </p>
           </CardContent>
         </Card>
 
-        <Card className="relative overflow-hidden border-0 shadow-lg hover:shadow-xl transition-all duration-300">
-          <div className="absolute inset-0 bg-gradient-to-br from-amber-500 to-amber-600 opacity-100" />
-          <CardHeader className="relative flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-white/90">In Progress</CardTitle>
-            <PlayCircle className="h-4 w-4 text-white/80" />
+        <Card className="bg-gradient-to-br from-orange-50 to-amber-50 border-orange-200">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium text-orange-700">In Progress</CardTitle>
+            <PlayCircle className="h-4 w-4 text-orange-600" />
           </CardHeader>
-          <CardContent className="relative">
-            <div className="text-2xl font-bold text-white">{stats.inProgress}</div>
-            <p className="text-xs text-white/80">
+          <CardContent>
+            <div className="text-2xl font-bold text-orange-700">{stats.inProgress}</div>
+            <p className="text-xs text-orange-600">
               Active jobs running
             </p>
           </CardContent>
         </Card>
 
-        <Card className="relative overflow-hidden border-0 shadow-lg hover:shadow-xl transition-all duration-300">
-          <div className="absolute inset-0 bg-gradient-to-br from-violet-500 to-violet-600 opacity-100" />
-          <CardHeader className="relative flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-white/90">Total Revenue</CardTitle>
-            <DollarSign className="h-4 w-4 text-white/80" />
+        <Card className="bg-gradient-to-br from-purple-50 to-violet-50 border-purple-200">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium text-purple-700">Total Revenue</CardTitle>
+            <DollarSign className="h-4 w-4 text-purple-600" />
           </CardHeader>
-          <CardContent className="relative">
-            <div className="text-2xl font-bold text-white">{symbol}{stats.totalRevenue.toLocaleString()}</div>
-            <p className="text-xs text-white/80">
+          <CardContent>
+            <div className="text-2xl font-bold text-purple-700">{symbol}{stats.totalRevenue.toLocaleString()}</div>
+            <p className="text-xs text-purple-600">
               From completed jobs
             </p>
           </CardContent>
         </Card>
 
-        <Card className="relative overflow-hidden border-0 shadow-lg hover:shadow-xl transition-all duration-300">
-          <div className="absolute inset-0 bg-gradient-to-br from-cyan-500 to-cyan-600 opacity-100" />
-          <CardHeader className="relative flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-white/90">Avg Duration</CardTitle>
-            <Timer className="h-4 w-4 text-white/80" />
+        <Card className="bg-gradient-to-br from-cyan-50 to-sky-50 border-cyan-200">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium text-cyan-700">Avg Duration</CardTitle>
+            <Timer className="h-4 w-4 text-cyan-600" />
           </CardHeader>
-          <CardContent className="relative">
-            <div className="text-2xl font-bold text-white">{formatDuration(stats.averageDuration)}</div>
-            <p className="text-xs text-white/80">
+          <CardContent>
+            <div className="text-2xl font-bold text-cyan-700">{formatDuration(stats.averageDuration)}</div>
+            <p className="text-xs text-cyan-600">
               Per completed job
             </p>
           </CardContent>
         </Card>
 
-        <Card className="relative overflow-hidden border-0 shadow-lg hover:shadow-xl transition-all duration-300">
-          <div className="absolute inset-0 bg-gradient-to-br from-red-500 to-red-600 opacity-100" />
-          <CardHeader className="relative flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-white/90">Overdue</CardTitle>
-            <AlertTriangle className="h-4 w-4 text-white/80" />
+        <Card className="bg-gradient-to-br from-red-50 to-rose-50 border-red-200">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium text-red-700">Overdue</CardTitle>
+            <AlertTriangle className="h-4 w-4 text-red-600" />
           </CardHeader>
-          <CardContent className="relative">
-            <div className="text-2xl font-bold text-white">{stats.overdueCards}</div>
-            <p className="text-xs text-white/80">
+          <CardContent>
+            <div className="text-2xl font-bold text-red-700">{stats.overdueCards}</div>
+            <p className="text-xs text-red-600">
               Need attention
             </p>
           </CardContent>

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -981,29 +981,27 @@ export default function Services() {
 
       {/* Enhanced Statistics Grid */}
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5">
-        <Card className="relative overflow-hidden border-0 shadow-lg hover:shadow-xl transition-all duration-300">
-          <div className="absolute inset-0 bg-gradient-to-br from-blue-500 to-blue-600 opacity-100" />
-          <CardHeader className="relative flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-white/90">Total Services</CardTitle>
-            <Package className="h-4 w-4 text-white/80" />
+        <Card className="bg-gradient-to-br from-blue-50 to-sky-50 border-blue-200">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium text-blue-700">Total Services</CardTitle>
+            <Package className="h-4 w-4 text-blue-600" />
           </CardHeader>
-          <CardContent className="relative">
-            <div className="text-2xl font-bold text-white">{services.length}</div>
-            <p className="text-xs text-white/80">
+          <CardContent>
+            <div className="text-2xl font-bold text-blue-700">{services.length}</div>
+            <p className="text-xs text-blue-600">
               {dashboard.active} active
             </p>
           </CardContent>
         </Card>
 
-        <Card className="relative overflow-hidden border-0 shadow-lg hover:shadow-xl transition-all duration-300">
-          <div className="absolute inset-0 bg-gradient-to-br from-emerald-500 to-emerald-600 opacity-100" />
-          <CardHeader className="relative flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-white/90">Total Revenue</CardTitle>
-            <DollarSign className="h-4 w-4 text-white/80" />
+        <Card className="bg-gradient-to-br from-green-50 to-emerald-50 border-green-200">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium text-green-700">Total Revenue</CardTitle>
+            <DollarSign className="h-4 w-4 text-green-600" />
           </CardHeader>
-          <CardContent className="relative">
-            <div className="text-2xl font-bold text-white">{formatPrice(dashboard.totalRevenue)}</div>
-            <p className="text-xs text-white/80">
+          <CardContent>
+            <div className="text-2xl font-bold text-green-700">{formatPrice(dashboard.totalRevenue)}</div>
+            <p className="text-xs text-green-600">
               {dashboard.totalBookings} bookings
             </p>
           </CardContent>
@@ -1011,43 +1009,40 @@ export default function Services() {
 
 
 
-        <Card className="relative overflow-hidden border-0 shadow-lg hover:shadow-xl transition-all duration-300">
-          <div className="absolute inset-0 bg-gradient-to-br from-pink-500 to-pink-600 opacity-100" />
-          <CardHeader className="relative flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-white/90">Avg Rating</CardTitle>
-            <Star className="h-4 w-4 text-white/80" />
+        <Card className="bg-gradient-to-br from-pink-50 to-rose-50 border-pink-200">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium text-pink-700">Avg Rating</CardTitle>
+            <Star className="h-4 w-4 text-pink-600" />
           </CardHeader>
-          <CardContent className="relative">
-            <div className="text-2xl font-bold text-white">{dashboard.avgRating.toFixed(1)}</div>
-            <p className="text-xs text-white/80">
+          <CardContent>
+            <div className="text-2xl font-bold text-pink-700">{dashboard.avgRating.toFixed(1)}</div>
+            <p className="text-xs text-pink-600">
               Customer rating
             </p>
           </CardContent>
         </Card>
 
-        <Card className="relative overflow-hidden border-0 shadow-lg hover:shadow-xl transition-all duration-300">
-          <div className="absolute inset-0 bg-gradient-to-br from-cyan-500 to-cyan-600 opacity-100" />
-          <CardHeader className="relative flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-white/90">Categories</CardTitle>
-            <Target className="h-4 w-4 text-white/80" />
+        <Card className="bg-gradient-to-br from-cyan-50 to-sky-50 border-cyan-200">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium text-cyan-700">Categories</CardTitle>
+            <Target className="h-4 w-4 text-cyan-600" />
           </CardHeader>
-          <CardContent className="relative">
-            <div className="text-2xl font-bold text-white">{dashboard.categoriesStats.length}</div>
-            <p className="text-xs text-white/80">
+          <CardContent>
+            <div className="text-2xl font-bold text-cyan-700">{dashboard.categoriesStats.length}</div>
+            <p className="text-xs text-cyan-600">
               Service types
             </p>
           </CardContent>
         </Card>
 
-        <Card className="relative overflow-hidden border-0 shadow-lg hover:shadow-xl transition-all duration-300">
-          <div className="absolute inset-0 bg-gradient-to-br from-red-500 to-red-600 opacity-100" />
-          <CardHeader className="relative flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-white/90">Inactive</CardTitle>
-            <AlertTriangle className="h-4 w-4 text-white/80" />
+        <Card className="bg-gradient-to-br from-red-50 to-rose-50 border-red-200">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium text-red-700">Inactive</CardTitle>
+            <AlertTriangle className="h-4 w-4 text-red-600" />
           </CardHeader>
-          <CardContent className="relative">
-            <div className="text-2xl font-bold text-white">{dashboard.inactive}</div>
-            <p className="text-xs text-white/80">
+          <CardContent>
+            <div className="text-2xl font-bold text-red-700">{dashboard.inactive}</div>
+            <p className="text-xs text-red-600">
               Need attention
             </p>
           </CardContent>

--- a/src/pages/Staff.tsx
+++ b/src/pages/Staff.tsx
@@ -824,17 +824,17 @@ export default function Staff() {
 
       {/* Dashboard Statistics */}
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        <Card className="bg-gradient-to-br from-blue-500 to-blue-600 text-white border-0 shadow-lg">
+        <Card className="bg-gradient-to-br from-blue-50 to-blue-100 border-blue-200">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium opacity-90 flex items-center gap-2">
+            <CardTitle className="text-sm font-medium text-blue-700 flex items-center gap-2">
               Total Staff
               <UsageBadge feature="staff" className="bg-card/20 text-card-foreground border-border/30" />
             </CardTitle>
-            <Users className="h-4 w-4 opacity-80" />
+            <Users className="h-4 w-4 text-blue-600" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{dashboardStats.totalStaff}</div>
-            <p className="text-xs opacity-80">
+            <div className="text-2xl font-bold text-blue-700">{dashboardStats.totalStaff}</div>
+            <p className="text-xs text-blue-600">
               {dashboardStats.activeStaff} active, {dashboardStats.inactiveStaff} inactive
               {(() => {
                 const access = getFeatureAccess('staff');
@@ -847,40 +847,40 @@ export default function Staff() {
           </CardContent>
         </Card>
 
-        <Card className="bg-gradient-to-br from-emerald-500 to-emerald-600 text-white border-0 shadow-lg">
+        <Card className="bg-gradient-to-br from-green-50 to-emerald-50 border-green-200">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium opacity-90">Active Staff</CardTitle>
-            <UserCheck className="h-4 w-4 opacity-80" />
+            <CardTitle className="text-sm font-medium text-green-700">Active Staff</CardTitle>
+            <UserCheck className="h-4 w-4 text-green-600" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{dashboardStats.activeStaff}</div>
-            <p className="text-xs opacity-80">
+            <div className="text-2xl font-bold text-green-700">{dashboardStats.activeStaff}</div>
+            <p className="text-xs text-green-600">
               {((dashboardStats.activeStaff / dashboardStats.totalStaff) * 100).toFixed(1)}% of total team
             </p>
           </CardContent>
         </Card>
 
-        <Card className="bg-gradient-to-br from-amber-500 to-amber-600 text-white border-0 shadow-lg">
+        <Card className="bg-gradient-to-br from-orange-50 to-amber-50 border-orange-200">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium opacity-90">New Hires</CardTitle>
-            <Clock className="h-4 w-4 opacity-80" />
+            <CardTitle className="text-sm font-medium text-orange-700">New Hires</CardTitle>
+            <Clock className="h-4 w-4 text-orange-600" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{dashboardStats.newHires}</div>
-            <p className="text-xs opacity-80">
+            <div className="text-2xl font-bold text-orange-700">{dashboardStats.newHires}</div>
+            <p className="text-xs text-orange-600">
               Joined in last 30 days
             </p>
           </CardContent>
         </Card>
 
-        <Card className="bg-gradient-to-br from-purple-500 to-purple-600 text-white border-0 shadow-lg">
+        <Card className="bg-gradient-to-br from-purple-50 to-violet-50 border-purple-200">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium opacity-90">Avg Commission</CardTitle>
-            <TrendingUp className="h-4 w-4 opacity-80" />
+            <CardTitle className="text-sm font-medium text-purple-700">Avg Commission</CardTitle>
+            <TrendingUp className="h-4 w-4 text-purple-600" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{dashboardStats.avgCommissionRate.toFixed(1)}%</div>
-            <p className="text-xs opacity-80">
+            <div className="text-2xl font-bold text-purple-700">{dashboardStats.avgCommissionRate.toFixed(1)}%</div>
+            <p className="text-xs text-purple-600">
               Average team rate
             </p>
           </CardContent>

--- a/src/pages/admin/AdminDashboard.tsx
+++ b/src/pages/admin/AdminDashboard.tsx
@@ -289,20 +289,20 @@ const AdminDashboard = () => {
         {/* Key Metrics */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           <Link to="/admin/organizations">
-            <Card className="bg-gradient-to-br from-blue-500 to-blue-600 text-white border-0 shadow-md hover:shadow-lg transition-shadow cursor-pointer">
+            <Card className="bg-gradient-to-br from-blue-50 to-blue-100 border-blue-200 dark:from-blue-950 dark:to-blue-900 dark:border-blue-800 hover:shadow-lg transition-shadow cursor-pointer">
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium text-white/90">Organizations</CardTitle>
-                <Building className="h-4 w-4 text-white/80" />
+                <CardTitle className="text-sm font-medium text-blue-700 dark:text-blue-300">Organizations</CardTitle>
+                <Building className="h-4 w-4 text-blue-600 dark:text-blue-400" />
               </CardHeader>
               <CardContent>
-                <div className="text-2xl font-bold">
+                <div className="text-2xl font-bold text-blue-700 dark:text-blue-200">
                   {loading ? '...' : stats.organizations.total.toLocaleString()}
                 </div>
                 <div className="flex items-center justify-between mt-2">
-                  <span className="text-xs text-white/80">
+                  <span className="text-xs text-blue-600 dark:text-blue-400">
                     +{stats.organizations.recent} this week
                   </span>
-                  <Badge variant="outline" className="text-xs bg-white/10 text-white border-white/20">
+                  <Badge variant="outline" className="text-xs bg-blue-100/60 text-blue-800 border-blue-200 dark:bg-blue-900/40 dark:text-blue-200 dark:border-blue-800">
                     {stats.organizations.active} active
                   </Badge>
                 </div>
@@ -311,20 +311,20 @@ const AdminDashboard = () => {
           </Link>
 
           <Link to="/admin/users">
-            <Card className="bg-gradient-to-br from-emerald-500 to-emerald-600 text-white border-0 shadow-md hover:shadow-lg transition-shadow cursor-pointer">
+            <Card className="bg-gradient-to-br from-emerald-50 to-green-100 border-emerald-200 dark:from-emerald-950 dark:to-emerald-900 dark:border-emerald-800 hover:shadow-lg transition-shadow cursor-pointer">
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium text-white/90">Users</CardTitle>
-                <Users className="h-4 w-4 text-white/80" />
+                <CardTitle className="text-sm font-medium text-emerald-700 dark:text-emerald-300">Users</CardTitle>
+                <Users className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
               </CardHeader>
               <CardContent>
-                <div className="text-2xl font-bold">
+                <div className="text-2xl font-bold text-emerald-700 dark:text-emerald-200">
                   {loading ? '...' : stats.users.total.toLocaleString()}
                 </div>
                 <div className="flex items-center justify-between mt-2">
-                  <span className="text-xs text-white/80">
+                  <span className="text-xs text-emerald-600 dark:text-emerald-400">
                     +{stats.users.recent} this week
                   </span>
-                  <Badge variant="outline" className="text-xs bg-white/10 text-white border-white/20">
+                  <Badge variant="outline" className="text-xs bg-emerald-100/60 text-emerald-800 border-emerald-200 dark:bg-emerald-900/40 dark:text-emerald-200 dark:border-emerald-800">
                     {stats.users.confirmed} confirmed
                   </Badge>
                 </div>
@@ -333,20 +333,20 @@ const AdminDashboard = () => {
           </Link>
 
           <Link to="/admin/subscription-plans">
-            <Card className="bg-gradient-to-br from-violet-500 to-violet-600 text-white border-0 shadow-md hover:shadow-lg transition-shadow cursor-pointer">
+            <Card className="bg-gradient-to-br from-purple-50 to-violet-50 border-purple-200 dark:from-violet-950 dark:to-violet-900 dark:border-violet-800 hover:shadow-lg transition-shadow cursor-pointer">
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium text-white/90">Subscriptions</CardTitle>
-                <CreditCard className="h-4 w-4 text-white/80" />
+                <CardTitle className="text-sm font-medium text-purple-700 dark:text-violet-300">Subscriptions</CardTitle>
+                <CreditCard className="h-4 w-4 text-purple-600 dark:text-violet-400" />
               </CardHeader>
               <CardContent>
-                <div className="text-2xl font-bold">
+                <div className="text-2xl font-bold text-purple-700 dark:text-violet-200">
                   {loading ? '...' : stats.subscriptions.active.toLocaleString()}
                 </div>
                 <div className="flex items-center justify-between mt-2">
-                  <span className="text-xs text-white/80">
+                  <span className="text-xs text-purple-600 dark:text-violet-400">
                     {stats.subscriptions.trial} trial
                   </span>
-                  <Badge variant="outline" className="text-xs bg-white/10 text-white border-white/20">
+                  <Badge variant="outline" className="text-xs bg-purple-100/60 text-purple-800 border-purple-200 dark:bg-violet-900/40 dark:text-violet-200 dark:border-violet-800">
                     {formatCurrency(stats.subscriptions.revenue)}/mo
                   </Badge>
                 </div>
@@ -355,23 +355,23 @@ const AdminDashboard = () => {
           </Link>
 
           <Link to="/admin/business-data">
-            <Card className="bg-gradient-to-br from-indigo-500 to-indigo-600 text-white border-0 shadow-md hover:shadow-lg transition-shadow cursor-pointer">
+            <Card className="bg-gradient-to-br from-indigo-50 to-blue-100 border-indigo-200 dark:from-indigo-950 dark:to-indigo-900 dark:border-indigo-800 hover:shadow-lg transition-shadow cursor-pointer">
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium text-white/90">Business Data</CardTitle>
-                <Database className="h-4 w-4 text-white/80" />
+                <CardTitle className="text-sm font-medium text-indigo-700 dark:text-indigo-300">Business Data</CardTitle>
+                <Database className="h-4 w-4 text-indigo-600 dark:text-indigo-400" />
               </CardHeader>
               <CardContent>
-                <div className="text-2xl font-bold">
+                <div className="text-2xl font-bold text-indigo-700 dark:text-indigo-200">
                   {loading ? '...' : Object.values(stats.businessData)
                     .reduce((sum, data) => sum + data.total, 0)
                     .toLocaleString()}
                 </div>
                 <div className="flex items-center justify-between mt-2">
-                  <span className="text-xs text-white/80">
+                  <span className="text-xs text-indigo-600 dark:text-indigo-400">
                     +{Object.values(stats.businessData)
                       .reduce((sum, data) => sum + data.recent, 0)} this week
                   </span>
-                  <Badge variant="outline" className="text-xs bg-white/10 text-white border-white/20">
+                  <Badge variant="outline" className="text-xs bg-indigo-100/60 text-indigo-800 border-indigo-200 dark:bg-indigo-900/40 dark:text-indigo-200 dark:border-indigo-800">
                     All records
                   </Badge>
                 </div>


### PR DESCRIPTION
Unify metric card design across all pages to match the light gradient style of the client Profile page.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d20a8fd-5c13-4410-8d01-2d2adf5b33d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9d20a8fd-5c13-4410-8d01-2d2adf5b33d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

