### PR TITLE
Reduce metric card height globally

### DIFF
--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -23,7 +23,7 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-responsive-sm sm:p-responsive-md", className)}
+    className={cn("flex flex-col space-y-1.5 p-responsive-xs sm:p-responsive-sm", className)}
     {...props}
   />
 ))
@@ -57,7 +57,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-responsive-sm sm:p-responsive-md pt-0", className)} {...props} />
+  <div ref={ref} className={cn("p-responsive-xs sm:p-responsive-sm pt-0", className)} {...props} />
 ))
 CardContent.displayName = "CardContent"
 
@@ -67,7 +67,7 @@ const CardFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex items-center p-responsive-sm sm:p-responsive-md pt-0", className)}
+    className={cn("flex items-center p-responsive-xs sm:p-responsive-sm pt-0", className)}
     {...props}
   />
 ))

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -584,13 +584,13 @@ const Dashboard = () => {
       <div className="grid grid-cols-responsive-compact gap-3 sm:gap-4">
         {todayStats.map((stat, index) => (
           <Card key={index} className={`${stat.bgClass}`}>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 p-3 sm:p-4 pb-2">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 p-2 sm:p-3 pb-2">
               <CardTitle className={`text-sm font-medium ${stat.textColor}`}>
                 {stat.title}
               </CardTitle>
               <stat.icon className={`h-4 w-4 ${stat.iconColor}`} />
             </CardHeader>
-            <CardContent className="p-3 sm:p-4">
+            <CardContent className="p-2 sm:p-3">
               <div className={`text-xl sm:text-2xl font-bold ${stat.valueColor}`}>{stat.value}</div>
               <div className="flex items-center mt-1">
                 {stat.change > 0 ? (


### PR DESCRIPTION
Reduce the height of metric cards by adjusting global card component paddings and specific dashboard card paddings.

---
<a href="https://cursor.com/background-agent?bcId=bc-1eb23ebe-0cf1-4cc7-b5c0-3881ee49f573">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1eb23ebe-0cf1-4cc7-b5c0-3881ee49f573">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

