### PR TITLE
Make job cards listing page wider

### DIFF
--- a/src/components/JobCardsList.tsx
+++ b/src/components/JobCardsList.tsx
@@ -279,7 +279,7 @@ export default function JobCardsList({ onRefresh }: JobCardsListProps) {
       <div className="space-y-4">
         {[1, 2, 3, 4, 5].map((i) => (
           <Card key={i} className="animate-pulse">
-            <CardContent className="p-6">
+            <CardContent className="p-4">
               <div className="flex items-center space-x-4">
                 <div className="w-12 h-12 bg-slate-200 rounded-full"></div>
                 <div className="flex-1 space-y-2">
@@ -329,10 +329,10 @@ export default function JobCardsList({ onRefresh }: JobCardsListProps) {
       </div>
 
       {/* Job Cards Grid */}
-      <div className="grid grid-cols-responsive-cards gap-4 sm:gap-6">
+      <div className="grid grid-cols-responsive-cards gap-3 sm:gap-4">
         {filteredJobCards.length === 0 ? (
           <Card>
-            <CardContent className="p-12 text-center">
+            <CardContent className="p-8 text-center">
               <div className="w-16 h-16 mx-auto mb-4 bg-slate-100 rounded-full flex items-center justify-center">
                 <Calendar className="w-8 h-8 text-slate-400" />
               </div>
@@ -347,7 +347,7 @@ export default function JobCardsList({ onRefresh }: JobCardsListProps) {
         ) : (
           filteredJobCards.map((card) => (
             <Card key={card.id} className="hover:shadow-lg transition-all duration-200 min-w-0">
-              <CardContent className="p-6">
+              <CardContent className="p-4">
                 <div className="flex items-start justify-between">
                   <div className="flex-1 space-y-4">
                     {/* Header */}

--- a/src/pages/JobCards.tsx
+++ b/src/pages/JobCards.tsx
@@ -279,7 +279,7 @@ export default function JobCards() {
   }, [jobCards]);
 
   return (
-    <div className="container mx-auto p-6 space-y-8 max-w-7xl">
+    <div className="container mx-auto p-4 space-y-6 max-w-[1600px]">
       {/* Header */}
       <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
         <div>
@@ -303,9 +303,9 @@ export default function JobCards() {
       </div>
 
       {/* Stats Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-5">
         <Card className="lg:col-span-1">
-          <CardContent className="p-6">
+          <CardContent className="p-4">
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm font-medium text-slate-600">Total Cards</p>
@@ -319,7 +319,7 @@ export default function JobCards() {
         </Card>
 
         <Card className="lg:col-span-1">
-          <CardContent className="p-6">
+          <CardContent className="p-4">
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm font-medium text-slate-600">Completed</p>
@@ -333,7 +333,7 @@ export default function JobCards() {
         </Card>
 
         <Card className="lg:col-span-1">
-          <CardContent className="p-6">
+          <CardContent className="p-4">
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm font-medium text-slate-600">In Progress</p>
@@ -347,7 +347,7 @@ export default function JobCards() {
         </Card>
 
         <Card className="lg:col-span-1">
-          <CardContent className="p-6">
+          <CardContent className="p-4">
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm font-medium text-slate-600">Total Revenue</p>
@@ -361,7 +361,7 @@ export default function JobCards() {
         </Card>
 
         <Card className="lg:col-span-1">
-          <CardContent className="p-6">
+          <CardContent className="p-4">
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm font-medium text-slate-600">Today</p>
@@ -375,7 +375,7 @@ export default function JobCards() {
         </Card>
 
         <Card className="lg:col-span-1">
-          <CardContent className="p-6">
+          <CardContent className="p-4">
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm font-medium text-slate-600">Completion Rate</p>
@@ -394,7 +394,7 @@ export default function JobCards() {
 
       {/* Filters */}
       <Card>
-        <CardContent className="p-6">
+        <CardContent className="p-4">
           <div className="flex flex-col lg:flex-row gap-4">
             <div className="flex-1">
               <div className="relative">


### PR DESCRIPTION
Widen the Job Cards listing page and reduce overall padding.

---
<a href="https://cursor.com/background-agent?bcId=bc-44f07572-94f5-42d8-b95d-8962446ec2f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-44f07572-94f5-42d8-b95d-8962446ec2f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

