### PR TITLE
Enlarge sidebar menu items

### DIFF
--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -423,10 +423,10 @@ export function AppSidebar() {
                         aria-expanded={isOpen}
                         aria-controls={`submenu-${item.title.toLowerCase().replace(/\s+/g, '-')}`}
                         aria-disabled={!isAvailable || undefined}
-                        className={`h-8 text-responsive-sm font-medium px-2 hover:bg-sidebar-accent/50 data-[active=true]:bg-sidebar-accent ${!isAvailable ? 'opacity-50' : ''}`}
+                        className={`h-9 text-responsive-base font-medium px-3 hover:bg-sidebar-accent/50 data-[active=true]:bg-sidebar-accent ${!isAvailable ? 'opacity-50' : ''}`}
                         tooltip={state === 'collapsed' ? item.title : undefined}
                       >
-                        <item.icon className="icon-responsive-sm flex-shrink-0 text-sidebar-primary/70" />
+                        <item.icon className="icon-responsive-md flex-shrink-0 text-sidebar-primary/70" />
                         <span className="flex-1 text-left truncate">{item.title}</span>
                         <div className="flex items-center gap-1 group-data-[collapsible=icon]:hidden flex-shrink-0">
                           {!isAvailable && <Lock className="w-3 h-3 text-sidebar-primary/40" />}
@@ -448,7 +448,7 @@ export function AppSidebar() {
                               <SidebarMenuSubItem key={subItem.title}>
                                 <SidebarMenuSubButton 
                                   asChild
-                                  className={`h-7 text-responsive-xs px-2 hover:bg-sidebar-accent/30 ${!subItemAvailable ? 'opacity-50 pointer-events-none' : ''}`}
+                                  className={`h-8 text-responsive-sm px-3 hover:bg-sidebar-accent/30 ${!subItemAvailable ? 'opacity-50 pointer-events-none' : ''}`}
                                   isActive={(item.title === 'Reports') ? (location.pathname === '/reports' && subItem.url.includes(`tab=${new URLSearchParams(location.search).get('tab') || 'overview'}`)) : (location.pathname === subItem.url)}
                                 >
                                   <NavLink
@@ -460,7 +460,7 @@ export function AppSidebar() {
                                     }
                                     onClick={handleNavClick}
                                   >
-                                    <subItem.icon className="icon-responsive-xs flex-shrink-0 text-sidebar-primary/60" />
+                                    <subItem.icon className="icon-responsive-sm flex-shrink-0 text-sidebar-primary/60" />
                                     <span className="flex-1 text-left truncate">{subItem.title}</span>
                                     <div className="flex items-center gap-1 flex-shrink-0">
                                       {!subItemAvailable && <Lock className="w-2.5 h-2.5 text-sidebar-primary/40" />}
@@ -480,7 +480,7 @@ export function AppSidebar() {
                   <SidebarMenuItem key={item.title}>
                      <SidebarMenuButton 
                        asChild
-                       className={`h-8 text-responsive-sm font-medium px-2 hover:bg-sidebar-accent/50 ${(!isAvailable && item.title !== 'Services') ? 'opacity-50 pointer-events-none' : ''}`}
+                       className={`h-9 text-responsive-base font-medium px-3 hover:bg-sidebar-accent/50 ${(!isAvailable && item.title !== 'Services') ? 'opacity-50 pointer-events-none' : ''}`}
                                    tooltip={state === 'collapsed' ? item.title : undefined}
                                    isActive={location.pathname === item.url}
                                  >
@@ -493,7 +493,7 @@ export function AppSidebar() {
                         }
                         onClick={handleNavClick}
                       >
-                        <item.icon className="icon-responsive-sm flex-shrink-0 text-sidebar-primary/70" />
+                        <item.icon className="icon-responsive-md flex-shrink-0 text-sidebar-primary/70" />
                         <span className="flex-1 text-left truncate">{item.title}</span>
                       </NavLink>
                     </SidebarMenuButton>
@@ -513,11 +513,11 @@ export function AppSidebar() {
                   <SidebarMenuButton 
                     asChild 
                     isActive={location.pathname === superAdminMenuItem.url}
-                    className="h-8 text-responsive-sm font-medium px-2 hover:bg-accent/30 data-[active=true]:bg-accent data-[active=true]:text-accent-foreground"
+                    className="h-9 text-responsive-base font-medium px-3 hover:bg-accent/30 data-[active=true]:bg-accent data-[active=true]:text-accent-foreground"
                     tooltip={state === 'collapsed' ? superAdminMenuItem.title : undefined}
                   >
                     <NavLink to={superAdminMenuItem.url} className={({ isActive }) => `flex items-center gap-2 w-full ${isActive ? 'text-accent-foreground' : 'text-sidebar-foreground'}`} onClick={handleNavClick}>
-                      <superAdminMenuItem.icon className="icon-responsive-sm flex-shrink-0 text-accent/70" />
+                      <superAdminMenuItem.icon className="icon-responsive-md flex-shrink-0 text-accent/70" />
                       <span className="flex-1 text-left truncate">{superAdminMenuItem.title}</span>
                       <Badge 
                         variant="outline" 
@@ -533,11 +533,11 @@ export function AppSidebar() {
                   <SidebarMenuButton
                     asChild
                     isActive={location.pathname === '/admin/cms'}
-                    className="h-8 text-responsive-sm font-medium px-2 hover:bg-accent/30 data-[active=true]:bg-accent data-[active=true]:text-accent-foreground"
+                    className="h-9 text-responsive-base font-medium px-3 hover:bg-accent/30 data-[active=true]:bg-accent data-[active=true]:text-accent-foreground"
                     tooltip={state === 'collapsed' ? 'Landing CMS' : undefined}
                   >
                     <NavLink to="/admin/cms" className={({ isActive }) => `flex items-center gap-2 w-full ${isActive ? 'text-accent-foreground' : 'text-sidebar-foreground'}`} onClick={handleNavClick}>
-                      <Sparkles className="icon-responsive-sm flex-shrink-0 text-accent/70" />
+                      <Sparkles className="icon-responsive-md flex-shrink-0 text-accent/70" />
                       <span className="flex-1 text-left truncate">Landing CMS</span>
                     </NavLink>
                   </SidebarMenuButton>

--- a/src/components/layout/SuperAdminSidebar.tsx
+++ b/src/components/layout/SuperAdminSidebar.tsx
@@ -159,15 +159,15 @@ export function SuperAdminSidebar() {
         <SidebarHeader className="px-2 pt-3">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2 text-purple-800">
-              <Crown className="h-5 w-5" />
-              <span className="font-semibold group-data-[collapsible=icon]:hidden">Admin Panel</span>
+              <Crown className="h-6 w-6" />
+              <span className="font-semibold group-data-[collapsible=icon]:hidden text-responsive-base">Admin Panel</span>
             </div>
-            <SidebarTrigger className="hidden md:inline-flex text-purple-700" />
+            <SidebarTrigger className="hidden md:inline-flex text-purple-700 h-7 w-7" />
           </div>
         </SidebarHeader>
         <SidebarGroup>
           <SidebarGroupLabel className="flex items-center gap-2 text-purple-700 font-semibold">
-            <Crown className="h-4 w-4" />
+            <Crown className="h-5 w-5" />
             Super Admin Panel
             <Badge variant="outline" className="ml-auto bg-purple-100 text-purple-700 border-purple-300">
               System
@@ -184,17 +184,17 @@ export function SuperAdminSidebar() {
                     <SidebarMenuItem key={item.title}>
                       <SidebarMenuButton
                         onClick={() => toggleSubmenu(item.title)}
-                        className="hover:bg-purple-100 text-slate-700 hover:text-purple-800 text-base"
+                        className="hover:bg-purple-100 text-slate-700 hover:text-purple-800 text-responsive-base h-12 px-3"
                         tooltip={state === 'collapsed' ? item.title : undefined}
                         size="lg"
                       >
-                        <item.icon className="w-5 h-5" />
+                        <item.icon className="w-6 h-6" />
                         <span className="flex-1">{item.title}</span>
                         <div className="group-data-[collapsible=icon]:hidden">
                           {isOpen ? (
-                            <ChevronDown className="w-5 h-5" />
+                            <ChevronDown className="w-6 h-6" />
                           ) : (
-                            <ChevronRight className="w-5 h-5" />
+                            <ChevronRight className="w-6 h-6" />
                           )}
                         </div>
                       </SidebarMenuButton>
@@ -204,7 +204,7 @@ export function SuperAdminSidebar() {
                             <SidebarMenuSubItem key={subItem.title}>
                               <SidebarMenuSubButton 
                                 asChild
-                                className="hover:bg-purple-100 h-9 text-[15px]"
+                                className="hover:bg-purple-100 h-10 text-responsive-sm px-3"
                                 isActive={location.pathname === subItem.url}
                               >
                                 <NavLink
@@ -218,7 +218,7 @@ export function SuperAdminSidebar() {
                                   }
                                   onClick={handleNavClick}
                                 >
-                                  <subItem.icon className="w-5 h-5" />
+                                  <subItem.icon className="w-6 h-6" />
                                   <span>{subItem.title}</span>
                                 </NavLink>
                               </SidebarMenuSubButton>
@@ -234,7 +234,7 @@ export function SuperAdminSidebar() {
                   <SidebarMenuItem key={item.title}>
                     <SidebarMenuButton 
                       asChild
-                      className="hover:bg-purple-100 text-base"
+                      className="hover:bg-purple-100 text-responsive-base h-12 px-3"
                       isActive={location.pathname === item.url}
                       tooltip={state === 'collapsed' ? item.title : undefined}
                       size="lg"
@@ -250,7 +250,7 @@ export function SuperAdminSidebar() {
                         }
                         onClick={handleNavClick}
                       >
-                        <item.icon className="w-5 h-5" />
+                        <item.icon className="w-6 h-6" />
                         <span>{item.title}</span>
                       </NavLink>
                     </SidebarMenuButton>


### PR DESCRIPTION
Enlarge sidebar menu items and icons in `AppSidebar` and `SuperAdminSidebar` for improved visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-32572811-dac7-4b38-8efa-bf72d5320057">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-32572811-dac7-4b38-8efa-bf72d5320057">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

