### PR TITLE
Enlarge sidebar component

### DIFF
--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -386,7 +386,7 @@ export function AppSidebar() {
   }, [location.pathname, location.search]);
 
   return (
-    <Sidebar role="navigation" aria-label="Primary" variant="inset" collapsible="icon" className="border-r border-sidebar-border bg-sidebar-background min-w-[240px] max-w-[240px] data-[collapsible=icon]:min-w-[52px] data-[collapsible=icon]:max-w-[52px]">
+    <Sidebar role="navigation" aria-label="Primary" variant="inset" collapsible="icon" className="border-r border-sidebar-border bg-sidebar-background min-w-[300px] max-w-[300px] data-[collapsible=icon]:min-w-[52px] data-[collapsible=icon]:max-w-[52px]">
       <SidebarContent className="px-0">
         <SidebarHeader className="px-3 py-2 border-b border-sidebar-border">
           <div className="flex items-center justify-between">

--- a/src/components/layout/SuperAdminSidebar.tsx
+++ b/src/components/layout/SuperAdminSidebar.tsx
@@ -154,7 +154,7 @@ export function SuperAdminSidebar() {
   }, [location.pathname]);
 
   return (
-    <Sidebar variant="inset" collapsible="icon" className="border-r max-w-[260px] md:max-w-[280px]">
+    <Sidebar variant="inset" collapsible="icon" className="border-r min-w-[300px] max-w-[300px] data-[collapsible=icon]:min-w-[52px] data-[collapsible=icon]:max-w-[52px]">
       <SidebarContent>
         <SidebarHeader className="px-2 pt-3">
           <div className="flex items-center justify-between">


### PR DESCRIPTION
Increase the width of the main and super admin sidebars to 300px, ensuring the super admin sidebar retains its collapsed state.

---
<a href="https://cursor.com/background-agent?bcId=bc-6163c309-22dd-4225-bf51-9681f32ca70e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6163c309-22dd-4225-bf51-9681f32ca70e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

