### PR TITLE
Apply setting tax rate to invoices

### DIFF
--- a/src/lib/saas/hooks.ts
+++ b/src/lib/saas/hooks.ts
@@ -329,9 +329,12 @@ export const useOrganizationCurrency = () => {
  */
 export const useOrganizationTaxRate = () => {
   const { organization } = useSaas()
-  
+  const raw = (organization?.settings as any)?.tax_rate_percent
+  const parsed = typeof raw === 'number' ? raw : typeof raw === 'string' ? parseFloat(raw) : 0
+
   return {
-    taxRate: 0.1, // 10% default
+    // Return tax rate as a percent value (e.g., 8.5 for 8.5%)
+    taxRate: Number.isFinite(parsed) ? parsed : 0,
     loading: false,
   }
 }

--- a/src/pages/InvoiceCreate.tsx
+++ b/src/pages/InvoiceCreate.tsx
@@ -582,7 +582,7 @@ export default function InvoiceCreate() {
               <div className="space-y-2">
                 <Label className="flex items-center space-x-2">
                   <input type="checkbox" checked={applyTax} onChange={(e) => setApplyTax(e.target.checked)} />
-                  <span>Apply Tax ({(orgTaxRate * 100).toFixed(1)}%)</span>
+                  <span>Apply Tax ({Number(orgTaxRate || 0).toFixed(2)}%)</span>
                 </Label>
               </div>
             </div>
@@ -661,7 +661,7 @@ export default function InvoiceCreate() {
                     </div>
                     {applyTax && (
                       <div className="flex justify-between">
-                        <span>Tax ({(orgTaxRate * 100).toFixed(1)}%):</span>
+                        <span>Tax ({Number(orgTaxRate || 0).toFixed(2)}%):</span>
                         <span>{symbol}{totals.taxAmount.toFixed(2)}</span>
                       </div>
                     )}

--- a/src/pages/InvoiceEdit.tsx
+++ b/src/pages/InvoiceEdit.tsx
@@ -559,7 +559,7 @@ export default function InvoiceEdit() {
                     </div>
                     {applyTax && (
                       <div className="flex justify-between">
-                        <span>Tax ({orgTaxRate}%):</span>
+                        <span>Tax ({Number(orgTaxRate || 0).toFixed(2)}%):</span>
                         <span>{symbol}{totals.taxAmount.toFixed(2)}</span>
                       </div>
                     )}


### PR DESCRIPTION
Update invoice create and edit pages to use the organization's configured tax rate for the "Apply Tax" checkbox and tax preview.

---
<a href="https://cursor.com/background-agent?bcId=bc-765642bd-fa3f-4272-890f-55ee7db697b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-765642bd-fa3f-4272-890f-55ee7db697b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

