### PR TITLE
Clean up and rename download options

### DIFF
--- a/src/pages/Invoices.tsx
+++ b/src/pages/Invoices.tsx
@@ -848,16 +848,10 @@ export default function Invoices() {
                               Edit
                             </DropdownMenuItem>
                             <DropdownMenuItem onClick={() => {
-                              downloadInvoicePDF(invoice, 'standard');
-                            }}>
-                              <FileText className="w-4 h-4 mr-2" />
-                              Download PDF (A4)
-                            </DropdownMenuItem>
-                            <DropdownMenuItem onClick={() => {
                               downloadInvoicePDF(invoice, '80mm');
                             }}>
                               <Receipt className="w-4 h-4 mr-2" />
-                              Download 80mm Receipt
+                              Download Receipt
                             </DropdownMenuItem>
                             <DropdownMenuItem>
                               <Mail className="w-4 h-4 mr-2" />


### PR DESCRIPTION
Remove the A4 PDF download option and rename the 80mm receipt download option to 'Download Receipt' as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba7b2e92-9b29-41b1-819c-7fe31f601eb5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba7b2e92-9b29-41b1-819c-7fe31f601eb5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

