### PR TITLE
Make account field mandatory for services

### DIFF
--- a/supabase/migrations/20251021093000_add_income_account_to_services.sql
+++ b/supabase/migrations/20251021093000_add_income_account_to_services.sql
@@ -1,0 +1,17 @@
+-- Add income_account_id to services and set up FK/index
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_schema = 'public' AND table_name = 'services' AND column_name = 'income_account_id'
+  ) THEN
+    ALTER TABLE public.services
+      ADD COLUMN income_account_id UUID REFERENCES public.accounts(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+-- Create index to speed up joins/filtering on income_account_id
+CREATE INDEX IF NOT EXISTS idx_services_income_account_id ON public.services(income_account_id);
+
+-- Optional backfill could be added here if a default Service Revenue account exists per organization.
+-- Leaving NULL to allow UI to enforce selection for new services while preserving existing rows.


### PR DESCRIPTION
Add a mandatory Income Account field to Services to allow users to specify the associated income account during creation.

---
<a href="https://cursor.com/background-agent?bcId=bc-e6d69072-41fc-475c-82ca-05b0137673b6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e6d69072-41fc-475c-82ca-05b0137673b6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

