### PR TITLE
Fix useTransactionNumbers undefined error

### DIFF
--- a/src/pages/InvoiceCreate.tsx
+++ b/src/pages/InvoiceCreate.tsx
@@ -12,6 +12,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { toast } from "sonner";
 import { Users, Receipt, Trash2, Plus, DollarSign } from "lucide-react";
 import { useOrganizationCurrency, useOrganizationTaxRate, useOrganization } from "@/lib/saas/hooks";
+import { useTransactionNumbers } from "@/hooks/useTransactionNumbers";
 
 
 interface Customer { id: string; full_name: string; email: string | null; phone: string | null }


### PR DESCRIPTION
Add missing import for `useTransactionNumbers` to resolve `ReferenceError: useTransactionNumbers is not defined`.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0b531bf-090f-40bc-8d76-a1a0d87d25ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0b531bf-090f-40bc-8d76-a1a0d87d25ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

