### PR TITLE
Layout invoice date and location fields

### DIFF
--- a/src/pages/InvoiceCreate.tsx
+++ b/src/pages/InvoiceCreate.tsx
@@ -422,12 +422,12 @@ export default function InvoiceCreate() {
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-end">
               <div className="space-y-2">
                 <Label htmlFor="due_date">Invoice Date</Label>
-                <Input className="w-48" id="due_date" type="date" value={formData.due_date} onChange={(e) => setFormData({ ...formData, due_date: e.target.value })} />
+                <Input className="w-full" id="due_date" type="date" value={formData.due_date} onChange={(e) => setFormData({ ...formData, due_date: e.target.value })} />
               </div>
               <div className="space-y-2">
                 <Label htmlFor="location_id">Location *</Label>
                 <Select value={formData.location_id} onValueChange={(v) => setFormData({ ...formData, location_id: v })}>
-                  <SelectTrigger>
+                  <SelectTrigger className="w-full">
                     <SelectValue placeholder={locations.length ? 'Select a location' : 'No locations found'} />
                   </SelectTrigger>
                   <SelectContent>


### PR DESCRIPTION
Make Invoice Date and Location fields 50% 50% on one row on the invoice create page.

---
<a href="https://cursor.com/background-agent?bcId=bc-979e16fc-4cb1-4f86-93f7-8f43994143bf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-979e16fc-4cb1-4f86-93f7-8f43994143bf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

