### PR TITLE
Style sidebar menus for light theme

### DIFF
--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -578,7 +578,7 @@ export function AppSidebar() {
                                 to={subItem.url}
                                 onClick={handleNavClick}
                                 className={cn(
-                                  "flex items-center gap-3 px-3 py-2.5 rounded-md text-sm transition-all duration-200",
+                                  "flex items-center gap-3 px-3 py-2.5 rounded-md text-sm transition-all duration-200 text-black dark:text-foreground font-medium",
                                   "hover:bg-accent hover:text-accent-foreground hover:scale-[1.02]",
                                   subItemActive && "bg-accent text-accent-foreground shadow-sm font-medium",
                                   !subItemAvailable && "opacity-50 pointer-events-none"

--- a/src/components/layout/SuperAdminSidebar.tsx
+++ b/src/components/layout/SuperAdminSidebar.tsx
@@ -184,7 +184,7 @@ export function SuperAdminSidebar() {
                     <SidebarMenuItem key={item.title}>
                       <SidebarMenuButton
                         onClick={() => toggleSubmenu(item.title)}
-                        className="hover:bg-purple-100 text-slate-700 hover:text-purple-800 text-responsive-base h-12 px-3"
+                        className="hover:bg-purple-100 text-black dark:text-slate-200 font-medium hover:text-purple-800 text-responsive-base h-12 px-3"
                         tooltip={state === 'collapsed' ? item.title : undefined}
                         size="lg"
                       >
@@ -204,7 +204,7 @@ export function SuperAdminSidebar() {
                             <SidebarMenuSubItem key={subItem.title}>
                               <SidebarMenuSubButton 
                                 asChild
-                                className="hover:bg-purple-100 h-10 text-responsive-sm px-3"
+                                className="hover:bg-purple-100 h-10 text-responsive-sm px-3 text-black dark:text-slate-200 font-medium"
                                 isActive={location.pathname === subItem.url}
                               >
                                 <NavLink
@@ -234,7 +234,7 @@ export function SuperAdminSidebar() {
                   <SidebarMenuItem key={item.title}>
                     <SidebarMenuButton 
                       asChild
-                      className="hover:bg-purple-100 text-responsive-base h-12 px-3"
+                      className="hover:bg-purple-100 text-black dark:text-slate-200 font-medium text-responsive-base h-12 px-3"
                       isActive={location.pathname === item.url}
                       tooltip={state === 'collapsed' ? item.title : undefined}
                       size="lg"

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -526,7 +526,7 @@ const SidebarMenuItem = React.forwardRef<
 SidebarMenuItem.displayName = "SidebarMenuItem"
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-3 overflow-hidden rounded-md p-3 text-left text-base outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-primary/10 hover:text-primary focus-visible:ring-2 active:bg-primary/20 active:text-primary disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-10 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-primary data-[active=true]:font-medium data-[active=true]:text-primary-foreground data-[state=open]:hover:bg-primary/20 data-[state=open]:hover:text-primary group-data-[collapsible=icon]:!size-9 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-3 overflow-hidden rounded-md p-3 text-left text-base text-black dark:text-sidebar-foreground font-medium outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-primary/10 hover:text-primary focus-visible:ring-2 active:bg-primary/20 active:text-primary disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-10 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-primary data-[active=true]:font-medium data-[active=true]:text-primary-foreground data-[state=open]:hover:bg-primary/20 data-[state=open]:hover:text-primary group-data-[collapsible=icon]:!size-9 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -736,7 +736,7 @@ const SidebarMenuSubButton = React.forwardRef<
       data-size={size}
       data-active={isActive}
       className={cn(
-        "flex h-9 min-w-0 -translate-x-px items-center gap-3 overflow-hidden rounded-md px-3 text-sidebar-foreground outline-none ring-sidebar-ring hover:bg-primary/10 hover:text-primary focus-visible:ring-2 active:bg-primary/20 active:text-primary disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0",
+        "flex h-9 min-w-0 -translate-x-px items-center gap-3 overflow-hidden rounded-md px-3 text-black dark:text-sidebar-foreground font-medium outline-none ring-sidebar-ring hover:bg-primary/10 hover:text-primary focus-visible:ring-2 active:bg-primary/20 active:text-primary disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0",
         "data-[active=true]:bg-primary data-[active=true]:text-primary-foreground",
         size === "sm" && "text-sm",
         size === "md" && "text-base",


### PR DESCRIPTION
Make all sidebar menu texts black and slightly bold in light theme to improve readability and aesthetics.

---
<a href="https://cursor.com/background-agent?bcId=bc-da4c3b6d-1457-43ff-b711-af11142d0930">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-da4c3b6d-1457-43ff-b711-af11142d0930">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

