### PR TITLE
Style sidebar and links for light theme

### DIFF
--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -470,9 +470,9 @@ export function AppSidebar() {
                         asChild={!!item.url && !(isCollapsed && hasSubItems)}
                         onClick={() => handleItemClick(item.title, hasSubItems)}
                         className={cn(
-                          "h-10 text-sm font-medium px-3 transition-all duration-200",
+                          "h-10 text-sm font-medium px-3 transition-all duration-200 text-black dark:text-sidebar-foreground",
                           "hover:bg-sidebar-accent/60 hover:scale-[1.02]",
-                          isActive && "bg-sidebar-accent text-sidebar-accent-foreground shadow-sm",
+                          isActive && "bg-sidebar-accent text-black dark:text-sidebar-accent-foreground shadow-sm",
                           !isAvailable && "opacity-50 pointer-events-none",
                           hasSubItems && "cursor-pointer"
                         )}
@@ -482,7 +482,7 @@ export function AppSidebar() {
                           <NavLink 
                             to={item.url} 
                             onClick={handleNavClick}
-                            className="flex items-center gap-3 w-full"
+                            className="flex items-center gap-3 w-full text-black dark:text-sidebar-foreground font-medium"
                           >
                             <item.icon className={cn(
                               "h-5 w-5 flex-shrink-0 transition-colors",
@@ -495,7 +495,7 @@ export function AppSidebar() {
                             )}
                           </NavLink>
                         ) : (
-                          <div className="flex items-center gap-3 w-full">
+                          <div className="flex items-center gap-3 w-full text-black dark:text-sidebar-foreground font-medium">
                             <item.icon className="h-5 w-5 flex-shrink-0 text-sidebar-foreground/70" />
                             {!isCollapsed && (
                               <>
@@ -527,16 +527,16 @@ export function AppSidebar() {
                                 key={subItem.title}
                                 asChild
                                 className={cn(
-                                  "h-8 text-xs px-3 ml-2 transition-all duration-200",
-                                  "hover:bg-sidebar-accent/40 hover:translate-x-1",
-                                  subItemActive && "bg-sidebar-accent/60 text-sidebar-accent-foreground",
+                                  "h-8 text-xs px-3 ml-2 transition-all duration-200 text-black dark:text-sidebar-foreground",
+                                  "hover:bg-sidebar-accent/40 hover:translate-x-1 hover:text-black dark:hover:text-sidebar-accent-foreground",
+                                  subItemActive && "bg-sidebar-accent/60 text-black dark:text-sidebar-accent-foreground",
                                   !subItemAvailable && "opacity-50 pointer-events-none"
                                 )}
                               >
                                 <NavLink 
                                   to={subItem.url} 
                                   onClick={handleNavClick}
-                                  className="flex items-center gap-2 w-full"
+                                  className="flex items-center gap-2 w-full text-black dark:text-sidebar-foreground font-medium"
                                 >
                                   <subItem.icon className={cn(
                                     "h-4 w-4 flex-shrink-0",
@@ -579,8 +579,8 @@ export function AppSidebar() {
                                 onClick={handleNavClick}
                                 className={cn(
                                   "flex items-center gap-3 px-3 py-2.5 rounded-md text-sm transition-all duration-200 text-black dark:text-foreground font-medium",
-                                  "hover:bg-accent hover:text-accent-foreground hover:scale-[1.02]",
-                                  subItemActive && "bg-accent text-accent-foreground shadow-sm font-medium",
+                                  "hover:bg-accent hover:text-black dark:hover:text-accent-foreground hover:scale-[1.02]",
+                                  subItemActive && "bg-accent text-black dark:text-accent-foreground shadow-sm font-medium",
                                   !subItemAvailable && "opacity-50 pointer-events-none"
                                 )}
                               >

--- a/src/components/layout/SuperAdminSidebar.tsx
+++ b/src/components/layout/SuperAdminSidebar.tsx
@@ -213,7 +213,7 @@ export function SuperAdminSidebar() {
                                     `flex items-center gap-2 ${
                                       isActive 
                                         ? "bg-purple-200 text-purple-900 font-medium" 
-                                        : "text-slate-700 hover:text-purple-800"
+                                        : "text-black dark:text-slate-200 hover:text-black dark:hover:text-purple-800 font-medium"
                                     }`
                                   }
                                   onClick={handleNavClick}
@@ -245,7 +245,7 @@ export function SuperAdminSidebar() {
                           `flex items-center gap-2 ${
                             isActive 
                               ? "bg-purple-200 text-purple-900 font-medium" 
-                              : "text-slate-700 hover:text-purple-800"
+                              : "text-black dark:text-slate-200 hover:text-black dark:hover:text-purple-800 font-medium"
                           }`
                         }
                         onClick={handleNavClick}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -526,13 +526,13 @@ const SidebarMenuItem = React.forwardRef<
 SidebarMenuItem.displayName = "SidebarMenuItem"
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-3 overflow-hidden rounded-md p-3 text-left text-base text-black dark:text-sidebar-foreground font-medium outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-primary/10 hover:text-primary focus-visible:ring-2 active:bg-primary/20 active:text-primary disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-10 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-primary data-[active=true]:font-medium data-[active=true]:text-primary-foreground data-[state=open]:hover:bg-primary/20 data-[state=open]:hover:text-primary group-data-[collapsible=icon]:!size-9 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-3 overflow-hidden rounded-md p-3 text-left text-base text-black dark:text-sidebar-foreground font-medium outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-primary/10 hover:text-black dark:hover:text-primary focus-visible:ring-2 active:bg-primary/20 active:text-black dark:active:text-primary disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-10 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-primary data-[active=true]:font-medium data-[active=true]:text-black dark:data-[active=true]:text-primary-foreground data-[state=open]:hover:bg-primary/20 data-[state=open]:hover:text-black dark:data-[state=open]:hover:text-primary group-data-[collapsible=icon]:!size-9 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+        default: "hover:bg-sidebar-accent hover:text-black dark:hover:text-sidebar-accent-foreground",
         outline:
-          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-black dark:hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
       },
       size: {
         default: "h-10 text-base",
@@ -736,8 +736,8 @@ const SidebarMenuSubButton = React.forwardRef<
       data-size={size}
       data-active={isActive}
       className={cn(
-        "flex h-9 min-w-0 -translate-x-px items-center gap-3 overflow-hidden rounded-md px-3 text-black dark:text-sidebar-foreground font-medium outline-none ring-sidebar-ring hover:bg-primary/10 hover:text-primary focus-visible:ring-2 active:bg-primary/20 active:text-primary disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0",
-        "data-[active=true]:bg-primary data-[active=true]:text-primary-foreground",
+        "flex h-9 min-w-0 -translate-x-px items-center gap-3 overflow-hidden rounded-md px-3 text-black dark:text-sidebar-foreground font-medium outline-none ring-sidebar-ring hover:bg-primary/10 hover:text-black dark:hover:text-primary focus-visible:ring-2 active:bg-primary/20 active:text-black dark:active:text-primary disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0",
+        "data-[active=true]:bg-primary data-[active=true]:text-black dark:data-[active=true]:text-primary-foreground",
         size === "sm" && "text-sm",
         size === "md" && "text-base",
         "group-data-[collapsible=icon]:hidden",


### PR DESCRIPTION
Enforce black, medium-bold text for all sidebar menu items and links in the light theme.

---
<a href="https://cursor.com/background-agent?bcId=bc-5493ce04-8acb-434b-acc7-2e22c3929a3d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5493ce04-8acb-434b-acc7-2e22c3929a3d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

