### PR TITLE
Style inactive buttons and tabs dark grey

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -14,10 +14,10 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90 border border-destructive/20 shadow-sm",
         outline:
-          "border border-primary text-primary bg-background hover:bg-primary hover:text-primary-foreground shadow-sm",
+          "border border-primary text-zinc-700 dark:text-muted-foreground bg-background hover:bg-primary hover:text-primary-foreground shadow-sm",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80 border border-secondary/20 shadow-sm",
-        ghost: "hover:bg-primary/10 hover:text-primary",
+        ghost: "text-zinc-700 dark:text-muted-foreground hover:bg-primary/10 hover:text-primary",
         link: "text-primary underline-offset-4 hover:underline hover:text-primary/80",
         solid: "bg-primary text-primary-foreground shadow-md hover:bg-primary/90 transition-all duration-200 border border-primary/20",
         "solid-destructive": "bg-destructive text-destructive-foreground shadow-md hover:bg-destructive/90 transition-all duration-200 border border-destructive/20",

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -12,7 +12,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "!inline-flex w-full overflow-x-auto flex-nowrap h-10 items-center justify-start sm:justify-center rounded-md bg-muted p-1 text-muted-foreground [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden gap-1 sm:gap-0",
+      "!inline-flex w-full overflow-x-auto flex-nowrap h-10 items-center justify-start sm:justify-center rounded-md bg-muted p-1 text-zinc-700 dark:text-muted-foreground [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden gap-1 sm:gap-0",
       className
     )}
     {...props}


### PR DESCRIPTION
Update unselected button and tab text colors to dark grey in the light theme.

---
<a href="https://cursor.com/background-agent?bcId=bc-13ea6add-fb51-4f92-b280-b2cdee346694">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-13ea6add-fb51-4f92-b280-b2cdee346694">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

