### PR TITLE
Style inactive elements for light theme

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -523,3 +523,31 @@ html, body, #root {
     background-image: linear-gradient(135deg, hsl(var(--muted)), hsl(var(--background))) !important;
   }
 }
+
+@layer base {
+  /* Light theme: disabled/inactive controls use lighter primary with black text */
+  :root:not(.dark) button:disabled,
+  :root:not(.dark) [role="button"][aria-disabled="true"],
+  :root:not(.dark) [aria-disabled="true"]:not(input):not(textarea),
+  :root:not(.dark) [data-disabled],
+  :root:not(.dark) [data-disabled="true"],
+  :root:not(.dark) .inactive,
+  :root:not(.dark) [data-state="inactive"] {
+    background-color: hsl(var(--primary-light)) !important;
+    color: hsl(0 0% 0%) !important;
+    border-color: hsl(var(--primary) / 0.2) !important;
+    opacity: 1 !important;
+  }
+
+  /* Light theme: disabled/inactive links (including menu anchors) should be black */
+  :root:not(.dark) a[aria-disabled="true"],
+  :root:not(.dark) a[data-disabled],
+  :root:not(.dark) a[data-disabled="true"],
+  :root:not(.dark) a.inactive,
+  :root:not(.dark) [data-sidebar="menu-sub-button"][aria-disabled="true"],
+  :root:not(.dark) [data-sidebar="menu-button"][aria-disabled="true"] {
+    color: hsl(0 0% 0%) !important;
+    text-decoration-color: hsl(0 0% 0% / 0.5);
+    opacity: 1 !important;
+  }
+}


### PR DESCRIPTION
Apply a lighter primary color with black text to inactive buttons, menus, and hyperlinks in the light theme.

---
<a href="https://cursor.com/background-agent?bcId=bc-7bd06892-f0dc-4908-95f9-cdb316ef94c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7bd06892-f0dc-4908-95f9-cdb316ef94c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

