### PR TITLE
Style tabs and buttons with theme colors

### DIFF
--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -12,7 +12,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "!inline-flex w-full overflow-x-auto flex-nowrap h-10 items-center justify-start sm:justify-center rounded-md bg-muted p-1 text-zinc-700 dark:text-muted-foreground [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden gap-1 sm:gap-0",
+      "!inline-flex w-full overflow-x-auto flex-nowrap h-10 items-center justify-start sm:justify-center rounded-md bg-muted p-1 text-zinc-700 dark:text-muted-foreground [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden gap-1.5",
       className
     )}
     {...props}
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-sm hover:bg-primary/10 hover:text-primary",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-sm bg-[hsl(var(--primary-lighter-70))] text-[hsl(var(--foreground))] hover:bg-primary/20 hover:text-primary",
       className
     )}
     {...props}

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -6,13 +6,13 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground",
+  "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors bg-[hsl(var(--primary-lighter-70))] text-[hsl(var(--foreground))] hover:bg-primary/20 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground",
   {
     variants: {
       variant: {
-        default: "bg-transparent",
+        default: "",
         outline:
-          "border border-input bg-transparent hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-transparent hover:bg-primary/10 hover:text-primary",
       },
       size: {
         default: "h-10 px-3",

--- a/src/index.css
+++ b/src/index.css
@@ -26,6 +26,7 @@ All colors MUST be HSL.
     --primary: var(--theme-primary, 220 70% 50%);
     --primary-foreground: var(--theme-primary-foreground, 0 0% 98%);
     --primary-light: var(--theme-primary-light, 220 70% 60%);
+    --primary-lighter-70: color-mix(in hsl, hsl(var(--primary)) 30%, hsl(0 0% 100%) 70%);
 
     --secondary: 0 0% 96.1%;
     --secondary-foreground: 0 0% 9%;
@@ -97,9 +98,8 @@ All colors MUST be HSL.
 
     /* Fixed footer height */
     --footer-height: 3.5rem; /* 56px */
-}
+  }
 
-@layer components {
   /* Freshsales-style compact text sizing */
   .text-responsive-xs { font-size: var(--text-xs); line-height: 1.3; }
   .text-responsive-sm { font-size: var(--text-sm); line-height: 1.35; }
@@ -202,7 +202,6 @@ All colors MUST be HSL.
       gap: 1rem;
     }
   }
-}
 
   .dark {
     /* Black and White Theme - Dark Mode */
@@ -219,6 +218,7 @@ All colors MUST be HSL.
     --primary: var(--theme-primary, 220 70% 50%);
     --primary-foreground: var(--theme-primary-foreground, 0 0% 9%);
     --primary-light: var(--theme-primary-light, 220 70% 40%);
+    --primary-lighter-70: color-mix(in hsl, hsl(var(--primary)) 30%, hsl(0 0% 0%) 70%);
 
     --secondary: 0 0% 14.9%;
     --secondary-foreground: 0 0% 98%;


### PR DESCRIPTION
Add a small gap between tabs and style active/inactive tabs and toggles with primary and 70% lighter primary theme colors respectively.

---
<a href="https://cursor.com/background-agent?bcId=bc-da3eb931-6efc-4768-b9c9-fd295e23cc8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-da3eb931-6efc-4768-b9c9-fd295e23cc8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

