### PR TITLE
Style active and inactive tabs

### DIFF
--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-sm bg-[hsl(var(--primary-lighter-70))] text-[hsl(var(--foreground))] hover:bg-primary/20 hover:text-primary",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-semibold ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-transparent bg-primary text-white hover:bg-primary/90 data-[state=active]:bg-white data-[state=active]:text-primary data-[state=active]:border-primary data-[state=active]:hover:bg-white data-[state=active]:hover:text-primary data-[state=active]:hover:border-primary",
       className
     )}
     {...props}


### PR DESCRIPTION
Style active tabs with a white background and primary border/text, and inactive tabs with a primary background and white text, with slightly bolder font.

---
<a href="https://cursor.com/background-agent?bcId=bc-d7f9080e-e68c-4737-97bc-e3ee1602b007">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d7f9080e-e68c-4737-97bc-e3ee1602b007">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

