### PR TITLE
Create theme save button

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -153,6 +153,19 @@ export default function Settings() {
         country: settings.country || '',
         currency: settings.currency || ''
       });
+
+      // Load saved branding/theme settings
+      if (settings.branding) {
+        const branding = settings.branding as any
+        if (branding.theme) {
+          setSelectedTheme(branding.theme)
+        }
+        if (branding.colors) {
+          setBrandColors(branding.colors)
+          // Apply to CSS variables so preview reflects saved branding
+          applyTheme({ primary: branding.colors.primary, accent: branding.colors.accent })
+        }
+      }
     }
   }, [organization]);
 
@@ -228,6 +241,34 @@ export default function Settings() {
     } catch (error) {
       console.error('Error saving company settings:', error);
       toast.error('Failed to save company settings');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const saveBrandingSettings = async () => {
+    if (!organization?.id || !updateOrganization) return;
+
+    try {
+      setLoading(true);
+
+      const currentSettings = (organization.settings as any) || {};
+      const updatedSettings = {
+        ...currentSettings,
+        branding: {
+          theme: selectedTheme,
+          colors: brandColors,
+        },
+      };
+
+      await updateOrganization(organization.id, {
+        settings: updatedSettings,
+      });
+
+      toast.success('Theme settings saved successfully');
+    } catch (error) {
+      console.error('Error saving theme settings:', error);
+      toast.error('Failed to save theme settings');
     } finally {
       setLoading(false);
     }
@@ -401,6 +442,12 @@ export default function Settings() {
                        <ThemeColorPicker />
                      </div>
                    </div>
+                 </div>
+                 <div className="flex justify-end pt-4 border-t">
+                   <Button onClick={saveBrandingSettings} disabled={loading} className="flex items-center gap-2">
+                     <Save className="h-4 w-4" />
+                     {loading ? 'Saving...' : 'Save Theme Settings'}
+                   </Button>
                  </div>
                 </div>
 


### PR DESCRIPTION
Add a "Save Theme Settings" button to the Branding tab to persist user-selected themes and brand colors.

---
<a href="https://cursor.com/background-agent?bcId=bc-091ba841-417d-402f-8e55-89f05be7416a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-091ba841-417d-402f-8e55-89f05be7416a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

