### PR TITLE
Fix missing created invoices

### DIFF
--- a/src/pages/InvoiceCreate.tsx
+++ b/src/pages/InvoiceCreate.tsx
@@ -486,6 +486,7 @@ export default function InvoiceCreate() {
         jobcard_id: formData.jobcard_id || null,
         jobcard_reference: formData.jobcard_reference || null,
         location_id: formData.location_id || null,
+        organization_id: organization?.id || undefined,
       };
       const created = await createInvoiceWithFallback(supabase, invoiceData, selectedItems);
 


### PR DESCRIPTION
Add `organization_id` to new invoices to ensure they are visible due to RLS policies.

The `invoices` table has Row Level Security (RLS) enabled and a `NOT NULL` constraint on `organization_id`. New invoices were previously created without this ID, causing them to be filtered out by RLS and not displayed. This change ensures `organization_id` is included during creation, making invoices visible, with a fallback for older database schemas.

---
<a href="https://cursor.com/background-agent?bcId=bc-4d1adbe3-c298-424c-82eb-907e8f76716f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4d1adbe3-c298-424c-82eb-907e8f76716f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

