### PR TITLE
Change quick actions card text to black in light theme

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -745,7 +745,7 @@ const Dashboard = () => {
                   <Button
                     key={index}
                     variant="outline"
-                    className={`${action.color} border-0 flex-col h-auto p-3 space-y-1`}
+                    className={`${action.color} border-0 flex-col h-auto p-3 space-y-1 text-black dark:text-white`}
                     onClick={action.action}
                   >
                     <action.icon className="w-5 h-5" />


### PR DESCRIPTION
Update Quick Actions button text to black in light theme for better visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae66a540-e2b3-4cf1-87ea-26367b26df0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ae66a540-e2b3-4cf1-87ea-26367b26df0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

