### PR TITLE
Restructure settings and sidebar menus

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,6 +50,7 @@ const PurchaseView = lazyWithRetry(() => import("./pages/PurchaseView"));
 const ExpenseForm = lazyWithRetry(() => import("./pages/ExpenseForm"));
 const StaffProfile = lazyWithRetry(() => import("./pages/StaffProfile"));
 const Settings = lazyWithRetry(() => import("./pages/Settings"));
+const ModulesSettings = lazyWithRetry(() => import("./pages/ModulesSettings"));
 const BrandingSettings = lazyWithRetry(() => import("./pages/BrandingSettings"));
 const Profile = lazyWithRetry(() => import("./pages/Profile"));
 const Help = lazyWithRetry(() => import("./pages/Help"));
@@ -307,6 +308,7 @@ const AppRoutes = () => {
           
           {/* Settings & Support */}
           <Route path="settings" element={<Settings />} />
+          <Route path="settings/modules" element={<ModulesSettings />} />
           <Route path="settings/branding" element={<BrandingSettings />} />
           <Route path="profile" element={<Profile />} />
           <Route path="help" element={<Help />} />

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -9,6 +9,7 @@ import {
   DollarSign,
   FileText,
   Settings,
+  Wrench,
   ChevronDown,
   ChevronRight,
   Building,
@@ -279,6 +280,12 @@ const menuItems: MenuItem[] = [
         title: "General Settings",
         url: "/settings",
         icon: Settings,
+        feature: "settings",
+      },
+      {
+        title: "Modules",
+        url: "/settings/modules",
+        icon: Wrench,
         feature: "settings",
       },
       {

--- a/src/pages/ModulesSettings.tsx
+++ b/src/pages/ModulesSettings.tsx
@@ -1,0 +1,19 @@
+import { ModuleManagement } from "@/components/settings/ModuleManagement";
+
+export default function ModulesSettings() {
+  return (
+    <div className="container mx-auto py-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Modules</h1>
+          <p className="text-muted-foreground">
+            Enable or disable application modules
+          </p>
+        </div>
+      </div>
+
+      <ModuleManagement />
+    </div>
+  );
+}
+

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -8,7 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Switch } from "@/components/ui/switch";
 import { Separator } from "@/components/ui/separator";
 import { Badge } from "@/components/ui/badge";
-import { Building, Wrench, CreditCard, Package, Users, UserCheck, MapPin, Warehouse, Save } from "lucide-react";
+import { Building, CreditCard, Package, UserCheck, MapPin, Warehouse, Save } from "lucide-react";
 import { toast } from "sonner";
 import { useOrganization } from "@/lib/saas/hooks";
 import { supabase } from "@/integrations/supabase/client";
@@ -16,7 +16,6 @@ import { useSearchParams, useNavigate } from "react-router-dom";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Globe } from "lucide-react";
 import { useSaas } from "@/lib/saas";
-import { ModuleManagement } from "@/components/settings/ModuleManagement";
 import { LocationsSettings } from "@/components/settings/LocationsSettings";
 import { WarehousesSettings } from "@/components/settings/WarehousesSettings";
 import { AccountingSettings } from "@/components/settings/AccountingSettings";
@@ -144,7 +143,7 @@ export default function Settings() {
       </div>
 
       <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
-        <TabsList className="grid w-full grid-cols-4 lg:grid-cols-7">
+        <TabsList className="grid w-full grid-cols-4 lg:grid-cols-5">
           <TabsTrigger value="company" className="justify-start gap-2 data-[state=active]:bg-muted">
             <Building className="h-4 w-4" />
             Company
@@ -164,14 +163,6 @@ export default function Settings() {
           <TabsTrigger value="warehouses" className="justify-start gap-2 data-[state=active]:bg-muted">
             <Warehouse className="h-4 w-4" />
             Warehouses
-          </TabsTrigger>
-          <TabsTrigger value="modules" className="justify-start gap-2 data-[state=active]:bg-muted">
-            <Wrench className="h-4 w-4" />
-            Modules
-          </TabsTrigger>
-          <TabsTrigger value="staff" className="justify-start gap-2 data-[state=active]:bg-muted">
-            <Users className="h-4 w-4" />
-            Staff
           </TabsTrigger>
         </TabsList>
 
@@ -277,29 +268,7 @@ export default function Settings() {
             <WarehousesSettings />
           </TabsContent>
 
-          {/* Modules Management */}
-          <TabsContent value="modules">
-            <ModuleManagement />
-          </TabsContent>
-
-          {/* Staff Management */}
-          <TabsContent value="staff">
-            <div className="grid gap-6">
-              <Card>
-                <CardHeader>
-                  <CardTitle>Staff Management</CardTitle>
-                  <CardDescription>
-                    Manage your team members and their permissions
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <div className="text-center py-8 text-muted-foreground">
-                    Staff management functionality will be implemented here.
-                  </div>
-                </CardContent>
-              </Card>
-            </div>
-          </TabsContent>
+          
         </div>
       </Tabs>
     </div>


### PR DESCRIPTION
Remove the Staff tab from Settings and move the Modules tab to a submenu under Settings in the sidebar.

---
<a href="https://cursor.com/background-agent?bcId=bc-40d9d411-ea84-4e0f-be98-6137ce8cdf1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-40d9d411-ea84-4e0f-be98-6137ce8cdf1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

