### PR TITLE
Update sidebar name from SalonFlow to AURA

### DIFF
--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -449,7 +449,7 @@ export function AppSidebar() {
               <div className="h-7 w-7 rounded-lg bg-muted border border-border flex-shrink-0 shadow-sm" />
               {!isCollapsed && (
                 <span className="font-semibold text-sm text-sidebar-foreground truncate animate-fade-in">
-                  SalonFlow
+                  AURA
                 </span>
               )}
             </div>


### PR DESCRIPTION
Replace "SalonFlow" with "AURA" in the sidebar branding.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0adf72d-6ba6-4e87-944f-12b2b996f856">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0adf72d-6ba6-4e87-944f-12b2b996f856">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

