### PR TITLE
Arrange quick themes and live preview cards

### DIFF
--- a/src/pages/BrandingSettings.tsx
+++ b/src/pages/BrandingSettings.tsx
@@ -203,7 +203,7 @@ export default function BrandingSettings() {
 
       <div className="space-y-6">
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
-          <Card className="lg:col-span-4 shadow-lg border-2 hover:shadow-xl transition-shadow animate-fade-in">
+          <Card className="lg:col-span-7 shadow-lg border-2 hover:shadow-xl transition-shadow animate-fade-in">
             <CardHeader className="bg-gradient-to-r from-primary/5 to-primary/10 border-b">
               <CardTitle className="flex items-center gap-2">
                 <Palette className="h-5 w-5 text-primary" />
@@ -238,7 +238,7 @@ export default function BrandingSettings() {
             </CardContent>
           </Card>
 
-          <Card className="lg:col-span-4 shadow-lg border-2 hover:shadow-xl transition-shadow animate-fade-in">
+          <Card className="lg:col-span-5 shadow-lg border-2 hover:shadow-xl transition-shadow animate-fade-in">
             <CardHeader className="bg-gradient-to-r from-secondary/5 to-secondary/10 border-b">
               <CardTitle className="flex items-center gap-2">
                 <Building className="h-5 w-5 text-primary" />


### PR DESCRIPTION
Adjust Quick Themes and Live Preview card column spans to achieve a 60%/40% layout split on large screens.

The Quick Themes card now spans 7 columns and the Live Preview card spans 5 columns, providing an approximate 60%/40% distribution within the 12-column grid on large screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-371078e4-5f0f-4ddb-8540-aa066697cd19">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-371078e4-5f0f-4ddb-8540-aa066697cd19">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

