### PR TITLE
Align settings and modules tabs left

### DIFF
--- a/src/components/settings/ModuleManagement.tsx
+++ b/src/components/settings/ModuleManagement.tsx
@@ -130,7 +130,7 @@ export function ModuleManagement() {
       </div>
 
       <Tabs defaultValue="modules" className="w-full">
-        <TabsList>
+        <TabsList className="justify-start sm:justify-start">
           <TabsTrigger value="modules">Modules</TabsTrigger>
           <TabsTrigger value="numbering">Transaction Numbering</TabsTrigger>
         </TabsList>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -143,7 +143,7 @@ export default function Settings() {
       </div>
 
       <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
-        <TabsList className="grid w-full grid-cols-4 lg:grid-cols-5">
+        <TabsList className="grid w-full grid-cols-4 lg:grid-cols-5 justify-start sm:justify-start">
           <TabsTrigger value="company" className="justify-start gap-2 data-[state=active]:bg-muted">
             <Building className="h-4 w-4" />
             Company


### PR DESCRIPTION
Left-align tabs in Settings and Module Management pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e963788-09bb-4eb3-a350-b4cae0e79c47">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8e963788-09bb-4eb3-a350-b4cae0e79c47">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

