### PR TITLE
Reorder navigation sub menus

### DIFF
--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -86,16 +86,16 @@ const menuItems: MenuItem[] = [
         feature: "clients",
       },
       {
-        title: "Invoices",
-        url: "/invoices",
-        icon: FileText,
-        feature: "accounting",
-      },
-      {
         title: "Job Cards",
         url: "/job-cards",
         icon: Scissors,
         feature: "job_cards",
+      },
+      {
+        title: "Invoices",
+        url: "/invoices",
+        icon: FileText,
+        feature: "accounting",
       },
       {
         title: "Payments Received",
@@ -265,16 +265,16 @@ const menuItems: MenuItem[] = [
     feature: "settings",
     subItems: [
       {
-        title: "Staff",
-        url: "/staff",
-        icon: User,
-        feature: "staff",
-      },
-      {
         title: "General Settings",
         url: "/settings",
         icon: Settings,
         feature: "settings",
+      },
+      {
+        title: "Staff",
+        url: "/staff",
+        icon: User,
+        feature: "staff",
       },
       {
         title: "Modules",


### PR DESCRIPTION
Reorder sidebar submenus to place Job Cards above Invoices and General Settings above Staff as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-a3de0e25-43d3-40ac-9a50-a3365eb6a441">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a3de0e25-43d3-40ac-9a50-a3365eb6a441">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

