### PR TITLE
Link transfers submenu to inventory transfers page

### DIFF
--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -167,7 +167,7 @@ const menuItems: MenuItem[] = [
       },
       {
         title: "Transfers",
-        url: "/stock-transfers",
+        url: "/inventory-transfers",
         icon: ArrowLeftRight,
         feature: "inventory",
       },


### PR DESCRIPTION
Link 'Transfers' submenu to the `/inventory-transfers` page.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ec4bab7-7315-48fa-a352-d1a1445c441d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4ec4bab7-7315-48fa-a352-d1a1445c441d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

