### PR TITLE
Align inventory transfer tabs left

### DIFF
--- a/src/pages/StockTransfers.tsx
+++ b/src/pages/StockTransfers.tsx
@@ -473,7 +473,7 @@ export default function StockTransfers() {
       </div>
 
       <Tabs defaultValue="new" className="space-y-6">
-        <TabsList>
+        <TabsList className="sm:!justify-start">
           <TabsTrigger value="new">New Transfer</TabsTrigger>
           <TabsTrigger value="history">History</TabsTrigger>
         </TabsList>


### PR DESCRIPTION
Left-align tabs on the Inventory Transfers window.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac162045-7ea4-40fb-abfc-0db4d971d8f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ac162045-7ea4-40fb-abfc-0db4d971d8f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

