### PR TITLE
Create commission report sub menu

### DIFF
--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -252,6 +252,12 @@ const menuItems: MenuItem[] = [
         feature: "reports",
       },
       {
+        title: "Commission Payable",
+        url: "/reports?type=commission-payable",
+        icon: DollarSign,
+        feature: "reports",
+      },
+      {
         title: "Payments Report",
         url: "/payments",
         icon: DollarSign,

--- a/src/pages/SpecificReports.tsx
+++ b/src/pages/SpecificReports.tsx
@@ -3,6 +3,7 @@ import { ProfitLossReport } from '@/components/reports/ProfitLossReport';
 import { BalanceSheetReport } from '@/components/reports/BalanceSheetReport';
 import { ExpenseReport } from '@/components/reports/ExpenseReport';
 import { CustomerReports } from '@/components/reports/CustomerReports';
+import { CommissionPayableReport } from '@/components/reports/CommissionPayableReport';
 import { useSearchParams } from 'react-router-dom';
 import { supabase } from '@/integrations/supabase/client';
 import { useOrganization } from '@/lib/saas/hooks';
@@ -60,6 +61,8 @@ const SpecificReports = () => {
       return <ExpenseReport {...commonProps} />;
     case 'customers':
       return <CustomerReports {...commonProps} />;
+    case 'commission-payable':
+      return <CommissionPayableReport {...commonProps} />;
     default:
       return <div>Report type not found</div>;
   }


### PR DESCRIPTION
Add 'Commission Payable' to the Reports submenu and link it to the `CommissionPayableReport` component for user access.

---
<a href="https://cursor.com/background-agent?bcId=bc-52ba8acc-298f-48f4-957b-63474c1a4aec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-52ba8acc-298f-48f4-957b-63474c1a4aec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

