### PR TITLE
Create commission report sub menu

### DIFF
--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -27,6 +27,7 @@ import {
   HelpCircle,
   ArrowLeftRight,
   Truck,
+  Activity,
 } from "lucide-react";
 import {
   Sidebar,
@@ -249,6 +250,12 @@ const menuItems: MenuItem[] = [
         title: "Customer Reports",
         url: "/reports?type=customers",
         icon: Users,
+        feature: "reports",
+      },
+      {
+        title: "Commission Payable",
+        url: "/reports?tab=commissions&sub=payable",
+        icon: Activity,
         feature: "reports",
       },
       {


### PR DESCRIPTION
Add 'Commission Payable' submenu under Reports to link to the Commission Payable report view.

---
<a href="https://cursor.com/background-agent?bcId=bc-7cefa610-6a5b-49e3-8e0a-43b369d17dba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7cefa610-6a5b-49e3-8e0a-43b369d17dba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

