### PR TITLE
Remove example commission accounting card

### DIFF
--- a/src/components/reports/CommissionPayableReport.tsx
+++ b/src/components/reports/CommissionPayableReport.tsx
@@ -377,25 +377,6 @@ export const CommissionPayableReport: React.FC<CommissionPayableReportProps> = (
         </CardContent>
       </Card>
 
-      {/* Example Section */}
-      <Card className="bg-blue-50 border-blue-200">
-        <CardHeader>
-          <CardTitle className="text-blue-800">Example: Commission Accounting</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-sm text-blue-700 space-y-2">
-            <p><strong>When commission is earned:</strong></p>
-            <p>Dr. Commission Expense: {formatMoney(5000, { decimals: 2 })}</p>
-            <p>Cr. Commission Payable: {formatMoney(5000, { decimals: 2 })}</p>
-            
-            <p className="pt-2"><strong>When commission is paid:</strong></p>
-            <p>Dr. Commission Payable: {formatMoney(3000, { decimals: 2 })}</p>
-            <p>Cr. Bank Account: {formatMoney(3000, { decimals: 2 })}</p>
-            
-            <p className="pt-2"><strong>Result:</strong> Balance of {formatMoney(2000, { decimals: 2 })} remains in Commission Payable (liability on balance sheet)</p>
-          </div>
-        </CardContent>
-      </Card>
     </div>
   );
 };


### PR DESCRIPTION
Remove the "Example: Commission Accounting" card from the Commission Payable report.

This card contained example accounting details and was requested to be removed to streamline the report.

---
<a href="https://cursor.com/background-agent?bcId=bc-292b50db-c868-405a-ac0d-862026e89bc7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-292b50db-c868-405a-ac0d-862026e89bc7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

