### PR TITLE
Link customer report to sidebar menu

### DIFF
--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -217,19 +217,19 @@ const menuItems: MenuItem[] = [
       },
       {
         title: "Profit and Loss",
-        url: "/reports?type=profit-loss",
+        url: "/specific-reports?type=profit-loss",
         icon: Calculator,
         feature: "reports",
       },
       {
         title: "Balance Sheet",
-        url: "/reports?type=balance-sheet",
+        url: "/specific-reports?type=balance-sheet",
         icon: FileText,
         feature: "reports",
       },
       {
         title: "Expense Report",
-        url: "/reports?type=expenses",
+        url: "/specific-reports?type=expenses",
         icon: CreditCard,
         feature: "reports",
       },
@@ -247,13 +247,13 @@ const menuItems: MenuItem[] = [
       },
       {
         title: "Customer Reports",
-        url: "/reports?type=customers",
+        url: "/specific-reports?type=customers",
         icon: Users,
         feature: "reports",
       },
       {
         title: "Commission Payable",
-        url: "/reports?type=commission-payable",
+        url: "/specific-reports?type=commission-payable",
         icon: DollarSign,
         feature: "reports",
       },


### PR DESCRIPTION
Update sidebar report links to use the `/specific-reports` path for specific report types, ensuring correct routing.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef36a250-69ee-4f51-8e5f-181dd640a347">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ef36a250-69ee-4f51-8e5f-181dd640a347">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

