### PR TITLE
Align staff profile tabs to general settings

### DIFF
--- a/src/pages/StaffProfile.tsx
+++ b/src/pages/StaffProfile.tsx
@@ -436,10 +436,10 @@ export default function StaffProfile() {
           <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-4">
             <div className="overflow-x-auto -mx-1 px-1">
               <TabsList className="min-w-max justify-start sm:justify-start">
-                <TabsTrigger value="activity" className="px-4 py-2 text-base">Activities</TabsTrigger>
-                <TabsTrigger value="schedule" className="px-4 py-2 text-base">Schedule</TabsTrigger>
-                <TabsTrigger value="commissions" className="px-4 py-2 text-base">Commissions</TabsTrigger>
-                <TabsTrigger value="gallery" className="px-4 py-2 text-base">Gallery</TabsTrigger>
+                <TabsTrigger value="activity" className="justify-start gap-2 data-[state=active]:bg-muted">Activities</TabsTrigger>
+                <TabsTrigger value="schedule" className="justify-start gap-2 data-[state=active]:bg-muted">Schedule</TabsTrigger>
+                <TabsTrigger value="commissions" className="justify-start gap-2 data-[state=active]:bg-muted">Commissions</TabsTrigger>
+                <TabsTrigger value="gallery" className="justify-start gap-2 data-[state=active]:bg-muted">Gallery</TabsTrigger>
               </TabsList>
             </div>
 


### PR DESCRIPTION
Reduce Staff Profile tab sizes and left-align them to match the General Settings page.

---
<a href="https://cursor.com/background-agent?bcId=bc-525a2404-dd07-4d37-b1c7-0be6b0871709">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-525a2404-dd07-4d37-b1c7-0be6b0871709">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

