### PR TITLE
Adjust job card side padding for responsiveness

### DIFF
--- a/src/pages/JobCards.tsx
+++ b/src/pages/JobCards.tsx
@@ -294,7 +294,7 @@ export default function JobCards() {
   }, [jobCards]);
 
   return (
-    <div className="container mx-auto p-1 sm:p-2 space-y-3 max-w-[1600px]">
+    <div className="mx-auto px-1 sm:px-2 py-2 space-y-3 w-full max-w-[1920px]">
       {/* Header */}
       <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-3">
         <div>


### PR DESCRIPTION
Reduce side padding and increase max width on the job cards listing to make it wider and more responsive.

---
<a href="https://cursor.com/background-agent?bcId=bc-094c9651-f261-41b4-8b92-4d5260b6ca18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-094c9651-f261-41b4-8b92-4d5260b6ca18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

