### PR TITLE
Return to invoice management on cancel

### DIFF
--- a/src/pages/InvoiceCreate.tsx
+++ b/src/pages/InvoiceCreate.tsx
@@ -811,7 +811,7 @@ Thank you for your business!`;
             </div>
           </div>
         <div className="flex gap-2">
-          <Button variant="outline" onClick={() => navigate(-1)}>Cancel</Button>
+          <Button variant="outline" onClick={() => navigate('/invoices')}>Cancel</Button>
           <Button variant="secondary" onClick={handleSubmit}>Save Invoice</Button>
           <Button onClick={handleSubmit}>Create Invoice</Button>
         </div>


### PR DESCRIPTION
Change the Create Invoice page's Cancel button to navigate directly to the Invoice Management page for consistent behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-37fa10c7-a782-4cac-851e-be082fd2b6ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-37fa10c7-a782-4cac-851e-be082fd2b6ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

